### PR TITLE
修正build.bat错误的将qnnlibs内的文件直接复制到assets目录下

### DIFF
--- a/app/src/main/cpp/build.bat
+++ b/app/src/main/cpp/build.bat
@@ -8,7 +8,7 @@ cmake --build --preset android-release
 if %ERRORLEVEL% neq 0 goto :error
 
 if not exist lib mkdir lib
-xcopy /Y /E .\build\android\qnnlibs ..\assets\
+xcopy /Y /E .\build\android\qnnlibs ..\assets\qnnlibs\
 if %ERRORLEVEL% neq 0 goto :error
 
 if not exist ..\jniLibs\arm64-v8a mkdir ..\jniLibs\arm64-v8a


### PR DESCRIPTION
修正build.bat错误的复制位置，
例如：
app/src/main/assets/libQnnSystem.so ✕

修正为：
app/src/main/assets/qnnlibs/libQnnSystem.so ✓