### PR TITLE
自动填写自定义模型名称

### DIFF
--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
@@ -2958,7 +2958,6 @@ private fun getFileNameFromUri(context: Context, uri: Uri): String? {
                 uri.lastPathSegment
             }
             else -> {
-                // 对于其他 scheme，尝试使用 DocumentFile
                 DocumentFile.fromSingleUri(context, uri)?.name
             }
         }


### PR DESCRIPTION
当导入自定义模型对话框的`模型名称`为空内容时，在选择模型`.zip`文件后，自动以文件名部分填写到`模型名称`中。