### PR TITLE
Add option to disable upscale resolution check

### DIFF
--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
@@ -972,6 +972,12 @@ fun ModelListScreen(
                                     )
                                 }
 
+                                var disableUpscaleResolutionCheck by remember {
+                                    mutableStateOf(
+                                        preferences.getBoolean("disable_upscale_resolution_check", false)
+                                    )
+                                }
+
                                 Row(
                                     modifier = Modifier
                                         .fillMaxWidth()
@@ -1018,6 +1024,41 @@ fun ModelListScreen(
                                         modifier = Modifier.weight(1f)
                                     ) {
                                         Text(
+                                            text = stringResource(R.string.disable_upscale_resolution_check),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                        Text(
+                                            stringResource(R.string.disable_upscale_resolution_check_hint),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                        )
+                                    }
+                                    Switch(
+                                        checked = disableUpscaleResolutionCheck,
+                                        onCheckedChange = {
+                                            disableUpscaleResolutionCheck = it
+                                            preferences.edit {
+                                                putBoolean("disable_upscale_resolution_check", it)
+                                            }
+                                        }
+                                    )
+                                }
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
+                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Column(
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Text(
                                             text = stringResource(R.string.show_process),
                                             style = MaterialTheme.typography.bodyMedium,
                                             fontWeight = FontWeight.Medium
@@ -1038,6 +1079,7 @@ fun ModelListScreen(
                                         }
                                     )
                                 }
+
                                 AnimatedVisibility(visible = showProcess) {
                                     Column {
                                         HorizontalDivider(

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/UpscaleScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/UpscaleScreen.kt
@@ -84,6 +84,11 @@ fun UpscaleScreen(
     val upscalerRepository = remember { UpscalerRepository(context) }
     val upscalerPreferences =
         remember { context.getSharedPreferences("upscaler_prefs", Context.MODE_PRIVATE) }
+    val appPreferences =
+        remember { context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE) }
+    val disableUpscaleResolutionCheck by remember {
+        mutableStateOf(appPreferences.getBoolean("disable_upscale_resolution_check", false))
+    }
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
@@ -96,25 +101,27 @@ fun UpscaleScreen(
                     }
 
                     if (bitmap != null) {
-                        val totalPixels = bitmap.width.toLong() * bitmap.height.toLong()
-                        val maxPixels = 2048L * 2048L
+                        if (!disableUpscaleResolutionCheck) {
+                            val totalPixels = bitmap.width.toLong() * bitmap.height.toLong()
+                            val maxPixels = 2048 * 2048L
 
-                        if (totalPixels > maxPixels) {
-                            withContext(Dispatchers.Main) {
-                                errorMessage = context.getString(
-                                    R.string.image_resolution_too_large,
-                                    bitmap.width,
-                                    bitmap.height
-                                )
+                            if (totalPixels > maxPixels) {
+                                withContext(Dispatchers.Main) {
+                                    errorMessage = context.getString(
+                                        R.string.image_resolution_too_large,
+                                        bitmap.width,
+                                        bitmap.height
+                                    )
+                                }
+                                return@launch
                             }
-                        } else {
-                            selectedImageUri = it
-                            selectedBitmap = bitmap
-                            withContext(Dispatchers.Main) {
-                                sharedScale = 1f
-                                sharedOffsetX = 0f
-                                sharedOffsetY = 0f
-                            }
+                        }
+                        selectedImageUri = it
+                        selectedBitmap = bitmap
+                        withContext(Dispatchers.Main) {
+                            sharedScale = 1f
+                            sharedOffsetX = 0f
+                            sharedOffsetY = 0f
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,7 +10,7 @@
     <string name="ponyv55_description">Pony Diffusionシリーズ</string>
     <string name="backend_notify">バックエンドサービス実行中</string>
     <string name="backend_notify_title">SD モデルのバックエンド</string>
-    <string name="generating_notify">画像の生成中...</string>
+    <string name="generating_notify">画像の生成中…</string>
     <string name="settings">設定</string>
     <string name="confirm">決定</string>
     <string name="cancel">取り消す</string>
@@ -56,6 +56,7 @@
     <string name="img2img_hint">img2img機能を使用します。必要がない場合や問題が発生しない場合はオフにしてください。</string>
     <string name="show_process">生成プロセスを表示</string>
     <string name="show_process_hint">NPU モデル専用機能です。</string>
+    <string name="disable_upscale_resolution_check_hint">有効にすると、超解像の解像度チェックをスキップします。画像の生成が遅くなったり、エラーが発生したりするおそれがあります。</string>
     <string name="preview_stride">プレビューストライド</string>
     <string name="preview_stride_hint">%d ステップごとにプレビューを更新します (1 ～ 10)。</string>
     <string name="download_patch">高解像度パッチをダウンロード</string>
@@ -129,14 +130,14 @@
     <string name="error_generation_failed">生成失敗: %s</string>
     <string name="unknown_error">不明なエラー</string>
     <string name="image_saved">画像をギャラリーに保存しました</string>
-    <string name="loading_model">モデルの読み込み中...</string>
+    <string name="loading_model">モデルの読み込み中…</string>
     <string name="file_manager">ファイル管理</string>
     <string name="file_manager_desc">モデルファイルの管理</string>
     <string name="delete_file">ファイルを削除</string>
     <string name="delete_file_confirm">ファイル「%s」を削除してもよろしいですか?</string>
     <string name="file_deleted">ファイルが正常に削除されました</string>
     <string name="no_model_files">モデルが見当たりません</string>
-    <string name="loading_files">ファイルを読み込み中...</string>
+    <string name="loading_files">ファイルを読み込み中…</string>
     <string name="back_to_folders">フォルダに戻る</string>
     <string name="model_folder">モデル: %s</string>
     <string name="file_count">%dのファイル</string>
@@ -157,7 +158,7 @@
     <string name="add_model">モデルを追加</string>
     <string name="custom_model_hint">SD1.5アーキテクチャセーフテンソルモデルファイルのみをサポートします</string>
     <string name="custom_npu_model_hint">NPUモデルファイルを含むZIPファイルを選択してください。Qualcommデバイスでのみ利用可能です。</string>
-    <string name="converting">変換中...</string>
+    <string name="converting">変換中…</string>
     <string name="model_conversion_success">モデル変換完了!</string>
     <string name="model_conversion_failed">変換に失敗しました: %s</string>
     <string name="npu_model_added_success">NPUモデルの追加に成功しました！</string>
@@ -219,4 +220,5 @@
     <string name="resolution">解像度</string>
     <string name="scheduler">スケジューラー</string>
     <string name="extracting">抽出中…</string>
+    <string name="disable_upscale_resolution_check">解像度チェックをスキップ</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -63,9 +63,11 @@
     <string name="no_npu_models">暂无模型</string>
     <string name="img2img_hint">开启img2img功能，如果你不需要或遇到问题请关闭</string>
     <string name="show_process">显示生成过程</string>
+    <string name="disable_upscale_resolution_check">禁用超分功能的分辨率检查</string>
+    <string name="disable_upscale_resolution_check_hint">启用时，禁用对超分辨率功能的分辨率检查。这可能导致图像生成缓慢或出现错误。</string>
     <string name="show_process_hint">仅对NPU模型生效。开启后将显示扩散模型的中间生成步骤。这会降低生成速度，仅在好奇图像生成过程时开启，正常情况下请关闭。</string>
     <string name="preview_stride">预览步长</string>
-    <string name="preview_stride_hint">每 %d 步更新一次预览（1-10）。</string>
+    <string name="preview_stride_hint">每 %d 步更新一次预览（1–10）。</string>
     <string name="download_patch">下载高分辨率补丁</string>
     <string name="download_patch_hint">要为模型%2$s下载%1$dx%1$d分辨率补丁吗? 使模型能够生成%1$d分辨率图像</string>
     <string name="highres_patch">HighRes Patch</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,8 +64,11 @@
     <string name="img2img_hint">Use img2img feature. Turn off if you don\'t need or encounter any problems.</string>
     <string name="show_process">Show Generation Process</string>
     <string name="show_process_hint">Only works for NPU models. Show intermediate generation steps. This will slow down generation speed. Enable only when curious about the process.</string>
+    <string name="disable_upscale_resolution_check">Disable Upscale Resolution Check</string>
+    <string name="disable_upscale_resolution_check_hint">When enabled, it disables the resolution check for Upscale. This may cause slow image generation or errors.</string>
+
     <string name="preview_stride">Preview Stride</string>
-    <string name="preview_stride_hint">Update preview every %d steps (1-10).</string>
+    <string name="preview_stride_hint">Update preview every %d steps (1–10).</string>
     <string name="download_patch">Download High Resolution Patch</string>
     <string name="download_patch_hint">Download %1$dx%1$d high resolution patch for %2$s? This will enable %1$dpx generation.</string>
     <string name="highres_patch">HighRes Patch</string>


### PR DESCRIPTION
New preference `disable_upscale_resolution_check` that allows users to bypass the 2048x2048 pixel limit when selecting images for upscaling.

*   **ModelListScreen.kt**: Add a toggle switch in the UI to manage the "Disable Upscale Resolution Check" preference.
*   **UpscaleScreen.kt**: Update image selection logic to respect the new preference, conditionally skipping the resolution validation.
*   **strings.xml**: Add English, Japanese, and Chinese localizations for the new setting and its description.