### PR TITLE
Exports BackendService so third-party apps can use Local-Dream as a service provider

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -66,6 +67,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        aidl = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,10 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <permission
-        android:name="io.github.xororz.localdream.permission.BIND_BACKEND"
-        android:protectionLevel="normal" />
-
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
@@ -53,8 +49,7 @@
             android:name=".service.BackendService"
             android:enabled="true"
             android:exported="true"
-            android:foregroundServiceType="dataSync"
-            android:permission="io.github.xororz.localdream.permission.BIND_BACKEND">
+            android:foregroundServiceType="dataSync">
 
             <!-- Restrict who can bind with a permission -->
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <permission
+        android:name="io.github.xororz.localdream.permission.BIND_BACKEND"
+        android:protectionLevel="normal" />
+
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
@@ -48,8 +52,15 @@
         <service
             android:name=".service.BackendService"
             android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:exported="true"
+            android:foregroundServiceType="dataSync"
+            android:permission="io.github.xororz.localdream.permission.BIND_BACKEND">
+
+            <!-- Restrict who can bind with a permission -->
+            <intent-filter>
+                <action android:name="io.github.xororz.localdream.BIND_SERVICE" />
+            </intent-filter>
+        </service>
 
         <service
             android:name=".service.BackgroundGenerationService"

--- a/app/src/main/aidl/io/github/xororz/localdream/ILocalDreamService.aidl
+++ b/app/src/main/aidl/io/github/xororz/localdream/ILocalDreamService.aidl
@@ -1,0 +1,19 @@
+package io.github.xororz.localdream;
+
+import io.github.xororz.localdream.data.ModelInfo;
+
+interface ILocalDreamService {
+    // Lifecycle
+    boolean startModel(String modelId, int width, int height);
+    void stopModel();
+
+    // State: 0=Idle, 1=Starting, 2=Running, -1=Error
+    int getState();
+    String getErrorMessage();
+
+    // The port the HTTP server is listening on
+    int getPort();
+
+    // get list of available models in Local-Dream
+    List<ModelInfo> getModels();
+}

--- a/app/src/main/aidl/io/github/xororz/localdream/ILocalDreamService.aidl
+++ b/app/src/main/aidl/io/github/xororz/localdream/ILocalDreamService.aidl
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Layla Network Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.xororz.localdream;
 
 import io.github.xororz.localdream.data.ModelInfo;

--- a/app/src/main/aidl/io/github/xororz/localdream/data/ModelInfo.aidl
+++ b/app/src/main/aidl/io/github/xororz/localdream/data/ModelInfo.aidl
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Layla Network Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 package io.github.xororz.localdream.data;
 
 parcelable ModelInfo;

--- a/app/src/main/aidl/io/github/xororz/localdream/data/ModelInfo.aidl
+++ b/app/src/main/aidl/io/github/xororz/localdream/data/ModelInfo.aidl
@@ -1,0 +1,3 @@
+package io.github.xororz.localdream.data;
+
+parcelable ModelInfo;

--- a/app/src/main/java/io/github/xororz/localdream/data/Model.kt
+++ b/app/src/main/java/io/github/xororz/localdream/data/Model.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.runBlocking
 import java.io.File
 import android.content.Intent
 import android.util.Log
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 data class Resolution(
     val width: Int,
@@ -97,6 +99,24 @@ sealed class DownloadResult {
     data class Error(val message: String) : DownloadResult()
     data class Progress(val progress: DownloadProgress) : DownloadResult()
 }
+
+// used in AIDL DTO
+@Parcelize
+data class ModelInfo(
+    val id: String,
+    val name: String,
+    val description: String,
+    val generationSize: Int = 512,
+    val textEmbeddingSize: Int = 768,
+    val isDownloaded: Boolean = false,
+    val needsUpgrade: Boolean = false,
+    val defaultPrompt: String = "",
+    val defaultNegativePrompt: String = "",
+    val runOnCpu: Boolean = false,
+    val useCpuClip: Boolean = false,
+    val isCustom: Boolean = false,
+    val isSdxl: Boolean = false
+) : Parcelable
 
 data class Model(
     val id: String,

--- a/app/src/main/java/io/github/xororz/localdream/service/BackendService.kt
+++ b/app/src/main/java/io/github/xororz/localdream/service/BackendService.kt
@@ -1,19 +1,26 @@
 package io.github.xororz.localdream.service
 
-import android.app.*
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
 import android.content.Intent
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import io.github.xororz.localdream.BuildConfig
+import io.github.xororz.localdream.ILocalDreamService
 import io.github.xororz.localdream.R
 import io.github.xororz.localdream.data.Model
+import io.github.xororz.localdream.data.ModelInfo
+import io.github.xororz.localdream.data.ModelRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
-import io.github.xororz.localdream.data.ModelRepository
-import io.github.xororz.localdream.BuildConfig
+
 
 class BackendService : Service() {
     private var process: Process? = null
@@ -52,8 +59,6 @@ class BackendService : Service() {
         createNotificationChannel()
         prepareRuntimeDir()
     }
-
-    override fun onBind(intent: Intent): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.i(TAG, "service started command: ${intent?.action}")
@@ -106,6 +111,64 @@ class BackendService : Service() {
         super.onTimeout(startId, fgsType)
         handleTimeout(fgsType)
     }
+
+    // the binder implementation
+    private val binder = object : ILocalDreamService.Stub() {
+
+        override fun startModel(modelId: String?, width: Int, height: Int): Boolean {
+            if (modelId == null) return false
+
+            val modelRepository = ModelRepository(this@BackendService)
+            val model = modelRepository.models.find { it.id == modelId } ?: return false
+
+            val success = startBackend(model, width, height)
+            if (success) updateState(BackendState.Running)
+            else updateState(BackendState.Error("Backend start failed"))
+            return success
+        }
+
+        override fun stopModel() {
+            stopBackend()
+        }
+
+        override fun getState(): Int = when (backendState.value) {
+            is BackendState.Idle -> 0
+            is BackendState.Starting -> 1
+            is BackendState.Running -> 2
+            is BackendState.Error -> -1
+        }
+
+        override fun getErrorMessage(): String? {
+            val state = backendState.value
+            return if (state is BackendState.Error) state.message else null
+        }
+
+        override fun getPort(): Int = 8081
+
+        override fun getModels(): MutableList<ModelInfo> {
+            val modelRepository = ModelRepository(this@BackendService)
+            return modelRepository.models.map { model ->
+                ModelInfo(
+                    id = model.id,
+                    name = model.name,
+                    description = model.description,
+                    isDownloaded = model.isDownloaded,
+                    isSdxl = model.isSdxl,
+                    isCustom = model.isCustom,
+                    runOnCpu = model.runOnCpu,
+                    useCpuClip = model.useCpuClip,
+                    needsUpgrade = model.needsUpgrade,
+                    defaultPrompt = model.defaultPrompt,
+                    generationSize = model.generationSize,
+                    textEmbeddingSize = model.textEmbeddingSize,
+                    defaultNegativePrompt = model.defaultNegativePrompt
+                )
+            }.toMutableList()
+        }
+    }
+
+    // Now return the binder
+    override fun onBind(intent: Intent): IBinder = binder
 
     private fun handleTimeout(fgsType: Int) {
         Log.e(TAG, "Foreground service timeout (fgsType=$fgsType)")


### PR DESCRIPTION
This PR exports the `BackendService` so external apps may use Local-Dream through a bound service to generate images.

Local dream works by spinning up a local server which accepts requests on port 8081. Exporting the service opens up Local-Dream to be used as a service.

The Binder ties into the existing local-dream service infrastructure, and exposes a few helper methods:
- `startModel`: starts the internal server
- `getState`: returns the current backend state
- `getErrorMessage`: returns the last error message from the local-dream backend
- `getPort`: hardcoded to 8081 at the moment
- `getModels`: returns a list of currently available models in Local-Dream. This list can be used by third-party apps to construct logic such as model picking, etc.

**Usage**
Third-party apps can attempt to bind to Local-Dream, if local-dream is not installed, show prompt:

<img width="350" alt="Screenshot_20260429_215849_Layla" src="https://github.com/user-attachments/assets/ef882618-2b2b-4a06-92c3-0ac0008ff321" />

Bind to service: this starts the `BackendService` in Local-Dream, which allows us to fetch the currently available models.

<img width="350" alt="VideoProject50-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/71201124-4fd9-4f3d-8e78-b3d2ecc23d51" />

You will be able to configure all generation parameters, then call Local-Dream to perform the generation:

<img width="350" alt="VideoProject501-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/a96b8db9-dc82-459c-87f2-8a7c03876dbd" />
