### PR TITLE
feat: Add OpenAI-compatible image API and CI build workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,194 @@
+name: Android Build
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  QAIRT_VERSION: 2.39.0.250926
+  QAIRT_URL: https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.39.0.250926/v2.39.0.250926.zip
+  ANDROID_NDK_VERSION: 28.0.13004108
+  ANDROID_NDK_ROOT: /data/android-ndk-r28
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Rust 1.84.0
+        uses: dtolnay/rust-toolchain@1.84.0
+        with:
+          targets: aarch64-linux-android
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # The repo vendors MNN as a recursive submodule, and one of its
+          # flatbuffers Android samples carries a wrapper jar that is outside
+          # Gradle's known-checksum list. We still use the root wrapper, so
+          # disable the action's repo-wide recursive validation here.
+          validate-wrappers: false
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install host build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache cmake ninja-build unzip
+
+      - name: Restore native build caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ccache
+            ~/.cargo/registry
+            ~/.cargo/git
+            app/src/main/cpp/3rdparty/tokenizers-cpp/rust/target
+            /tmp/qairt-download
+          key: native-build-${{ runner.os }}-${{ env.QAIRT_VERSION }}-${{ env.ANDROID_NDK_VERSION }}-${{ hashFiles('app/src/main/cpp/CMakeLists.txt', 'app/src/main/cpp/build.sh', 'app/src/main/cpp/CMakePresets.json', 'app/src/main/cpp/SampleApp.patch', '.gitmodules') }}
+          restore-keys: |
+            native-build-${{ runner.os }}-${{ env.QAIRT_VERSION }}-${{ env.ANDROID_NDK_VERSION }}-
+
+      - name: Install Android SDK packages
+        run: |
+          if ! sdkmanager "platform-tools" "platforms;android-37.0" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"; then
+            sdkmanager "platform-tools" "platforms;android-37" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          fi
+          mkdir -p "${ANDROID_SDK_ROOT}/platforms"
+          if [ -d "${ANDROID_SDK_ROOT}/platforms/android-37.0" ]; then
+            ln -sfn "${ANDROID_SDK_ROOT}/platforms/android-37.0" "${ANDROID_SDK_ROOT}/platforms/android-37"
+          fi
+          sudo mkdir -p /data
+          sudo ln -sfn "${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}" "${ANDROID_NDK_ROOT}"
+
+      - name: Download Qualcomm AI Runtime SDK
+        run: |
+          if [ -f /tmp/qairt-download/qairt.zip ]; then
+            echo "Using cached QAIRT zip"
+          else
+            rm -rf /tmp/qairt-download
+            mkdir -p /tmp/qairt-download
+            curl -L "${QAIRT_URL}" -o /tmp/qairt-download/qairt.zip
+          fi
+          rm -rf /tmp/qairt-download/raw
+          mkdir -p /tmp/qairt-download/raw
+          unzip -q /tmp/qairt-download/qairt.zip -d /tmp/qairt-download/raw
+
+          SDK_ROOT=""
+          if [ -d "/tmp/qairt-download/raw/${QAIRT_VERSION}/include/QNN" ]; then
+            SDK_ROOT="/tmp/qairt-download/raw/${QAIRT_VERSION}"
+          elif [ -d "/tmp/qairt-download/raw/${QAIRT_VERSION}/${QAIRT_VERSION}/include/QNN" ]; then
+            SDK_ROOT="/tmp/qairt-download/raw/${QAIRT_VERSION}/${QAIRT_VERSION}"
+          elif [ -d "/tmp/qairt-download/raw/${QAIRT_VERSION}" ]; then
+            SDK_ROOT="/tmp/qairt-download/raw/${QAIRT_VERSION}"
+          else
+            FIRST_DIR="$(find /tmp/qairt-download/raw -type d -path '*/include/QNN' | head -n 1)"
+            if [ -n "${FIRST_DIR}" ]; then
+              SDK_ROOT="$(dirname "$(dirname "${FIRST_DIR}")")"
+            else
+              SDK_ROOT="/tmp/qairt-download/raw"
+            fi
+          fi
+
+          sudo mkdir -p /data/qairt
+          sudo rm -rf "/data/qairt/${QAIRT_VERSION}"
+          sudo mv "${SDK_ROOT}" "/data/qairt/${QAIRT_VERSION}"
+
+      - name: Inspect QAIRT layout
+        run: |
+          echo "QAIRT root:"
+          find "/data/qairt/${QAIRT_VERSION}" -maxdepth 4 -type d | sort | sed -n '1,200p'
+          echo "QnnTypes.h candidates:"
+          find "/data/qairt/${QAIRT_VERSION}" -type f -name QnnTypes.h | sort | sed -n '1,50p'
+          echo "SampleApp candidates:"
+          find "/data/qairt/${QAIRT_VERSION}" -type f -path '*SampleApp*/src/QnnSampleApp.cpp' | sort | sed -n '1,50p'
+          echo "libQnnHtp.so candidates:"
+          find "/data/qairt/${QAIRT_VERSION}" -type f -name libQnnHtp.so | sort | sed -n '1,50p'
+
+      - name: Build native backend
+        working-directory: app/src/main/cpp
+        run: |
+          ccache --max-size=1G
+          ccache --show-config
+          ./build.sh
+
+      - name: Assemble debug APKs
+        run: ./gradlew --stacktrace :app:assembleBasicDebug :app:assembleFilterDebug
+
+      - name: Run unit tests
+        run: ./gradlew --stacktrace :app:testBasicDebugUnitTest :app:testFilterDebugUnitTest
+
+      - name: Run formatting checks
+        run: ./gradlew --stacktrace :app:ktlintCheck
+
+      - name: Restore release keystore
+        if: github.event_name != 'pull_request'
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "${RELEASE_KEYSTORE_BASE64}" ]; then
+            echo "Missing RELEASE_KEYSTORE_BASE64 secret" >&2
+            exit 1
+          fi
+          keystore_path="${RUNNER_TEMP}/release-keystore.jks"
+          echo "RELEASE_KEYSTORE_PATH=${keystore_path}" >> "${GITHUB_ENV}"
+          printf '%s' "${RELEASE_KEYSTORE_BASE64}" | base64 --decode > "${keystore_path}"
+
+      - name: Assemble signed release artifacts
+        if: github.event_name != 'pull_request'
+        env:
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          ./gradlew --stacktrace \
+            -PRELEASE_STORE_FILE="${RELEASE_KEYSTORE_PATH}" \
+            -PRELEASE_STORE_PASSWORD="${RELEASE_STORE_PASSWORD}" \
+            -PRELEASE_KEY_ALIAS="${RELEASE_KEY_ALIAS}" \
+            -PRELEASE_KEY_PASSWORD="${RELEASE_KEY_PASSWORD}" \
+            :app:assembleBasicRelease \
+            :app:assembleFilterRelease
+
+      - name: Upload debug artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-dream-debug-artifacts
+          path: |
+            app/build/outputs/apk/basic/debug/*.apk
+            app/build/outputs/apk/filter/debug/*.apk
+            app/src/main/jniLibs/arm64-v8a/libstable_diffusion_core.so
+          if-no-files-found: error
+
+      - name: Upload signed release artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-dream-release-artifacts
+          path: |
+            app/build/outputs/apk/basic/release/*.apk
+            app/build/outputs/apk/filter/release/*.apk
+          if-no-files-found: error

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,9 @@ android {
         buildConfig = true
     }
     packaging {
+        dex {
+            useLegacyPackaging = true
+        }
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -7,7 +7,74 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # QNN SDK PATH
 set(QNN_SDK_ROOT /data/qairt/2.39.0.250926)
 
-file(COPY ${QNN_SDK_ROOT}/examples/QNN/SampleApp/SampleApp/
+function(first_existing_path out_var)
+    foreach(candidate IN LISTS ARGN)
+        if(EXISTS "${candidate}")
+            set(${out_var} "${candidate}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
+first_existing_path(QNN_ROOT_CANDIDATE
+    ${QNN_SDK_ROOT}/2.39.0.250926
+    ${QNN_SDK_ROOT}
+    ${QNN_SDK_ROOT}/QAIRT
+    ${QNN_SDK_ROOT}/qairt
+)
+if(NOT QNN_ROOT_CANDIDATE)
+    set(QNN_ROOT_CANDIDATE ${QNN_SDK_ROOT})
+endif()
+
+first_existing_path(QNN_INCLUDE_DIR
+    ${QNN_ROOT_CANDIDATE}/include/QNN
+    ${QNN_SDK_ROOT}/include/QNN
+    ${QNN_ROOT_CANDIDATE}/QNN/include/QNN
+    ${QNN_SDK_ROOT}/QNN/include/QNN
+)
+if(NOT QNN_INCLUDE_DIR)
+    find_path(QNN_INCLUDE_DIR
+        NAMES QnnTypes.h
+        PATHS
+            ${QNN_ROOT_CANDIDATE}
+            ${QNN_SDK_ROOT}
+        PATH_SUFFIXES
+            include/QNN
+            QNN/include/QNN
+        NO_DEFAULT_PATH
+    )
+endif()
+if(NOT QNN_INCLUDE_DIR)
+    message(FATAL_ERROR "Could not locate QNN include directory under ${QNN_SDK_ROOT}")
+endif()
+get_filename_component(QNN_RESOLVED_SDK_ROOT "${QNN_INCLUDE_DIR}/../.." ABSOLUTE)
+message(STATUS "Resolved QNN SDK root: ${QNN_RESOLVED_SDK_ROOT}")
+
+first_existing_path(QNN_SAMPLEAPP_SOURCE
+    ${QNN_RESOLVED_SDK_ROOT}/examples/QNN/SampleApp/SampleApp
+    ${QNN_RESOLVED_SDK_ROOT}/examples/SampleApp/SampleApp
+    ${QNN_RESOLVED_SDK_ROOT}/examples/QNN/SampleApp
+    ${QNN_RESOLVED_SDK_ROOT}/SampleApp/SampleApp
+    ${QNN_RESOLVED_SDK_ROOT}/SampleApp
+)
+if(NOT QNN_SAMPLEAPP_SOURCE)
+    file(GLOB_RECURSE QNN_SAMPLEAPP_CANDIDATES LIST_DIRECTORIES true
+        ${QNN_RESOLVED_SDK_ROOT}/*SampleApp
+        ${QNN_RESOLVED_SDK_ROOT}/*/*SampleApp
+        ${QNN_RESOLVED_SDK_ROOT}/*/*/*SampleApp)
+    foreach(candidate IN LISTS QNN_SAMPLEAPP_CANDIDATES)
+        if(EXISTS "${candidate}/src/QnnSampleApp.cpp")
+            set(QNN_SAMPLEAPP_SOURCE "${candidate}")
+            break()
+        endif()
+    endforeach()
+endif()
+if(NOT QNN_SAMPLEAPP_SOURCE)
+    message(FATAL_ERROR "Could not locate QNN SampleApp under ${QNN_RESOLVED_SDK_ROOT}")
+endif()
+
+file(COPY ${QNN_SAMPLEAPP_SOURCE}/
     DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/SampleApp)
 execute_process(COMMAND git apply --directory=app/src/main/cpp/ --verbose ${CMAKE_CURRENT_SOURCE_DIR}/SampleApp.patch
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20,46 +87,76 @@ message(STATUS "Patch: ${patch_output}")
 message(STATUS "Patch: ${patch_error}")
 
 make_directory(${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtp.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnSystem.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV68Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV69Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV73Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV75Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV79Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/aarch64-android/libQnnHtpV81Stub.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v68/unsigned/libQnnHtpV68.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v69/unsigned/libQnnHtpV69.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v69/unsigned/libQnnHtpV69Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v73/unsigned/libQnnHtpV73.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v73/unsigned/libQnnHtpV73Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v75/unsigned/libQnnHtpV75.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v75/unsigned/libQnnHtpV75Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v79/unsigned/libQnnHtpV79.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v79/unsigned/libQnnHtpV79Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v81/unsigned/libQnnHtpV81.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
-file(COPY ${QNN_SDK_ROOT}/lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
+set(QNN_ANDROID_LIB_DIR "")
+foreach(candidate
+    ${QNN_RESOLVED_SDK_ROOT}/lib/aarch64-android
+    ${QNN_RESOLVED_SDK_ROOT}/lib/android
+    ${QNN_RESOLVED_SDK_ROOT}/libs/aarch64-android
+    ${QNN_RESOLVED_SDK_ROOT}/lib)
+    if(EXISTS "${candidate}/libQnnHtp.so")
+        set(QNN_ANDROID_LIB_DIR "${candidate}")
+        break()
+    endif()
+endforeach()
+if(NOT QNN_ANDROID_LIB_DIR)
+    file(GLOB_RECURSE QNN_HTP_LIB_CANDIDATES
+        ${QNN_RESOLVED_SDK_ROOT}/*/libQnnHtp.so
+        ${QNN_RESOLVED_SDK_ROOT}/*/*/libQnnHtp.so
+        ${QNN_RESOLVED_SDK_ROOT}/*/*/*/libQnnHtp.so)
+    list(LENGTH QNN_HTP_LIB_CANDIDATES QNN_HTP_LIB_COUNT)
+    if(QNN_HTP_LIB_COUNT GREATER 0)
+        list(GET QNN_HTP_LIB_CANDIDATES 0 QNN_HTP_LIB_PATH)
+        get_filename_component(QNN_ANDROID_LIB_DIR "${QNN_HTP_LIB_PATH}" DIRECTORY)
+    endif()
+endif()
+if(NOT QNN_ANDROID_LIB_DIR)
+    message(FATAL_ERROR "Could not locate Android QNN libraries under ${QNN_RESOLVED_SDK_ROOT}")
+endif()
+
+foreach(lib_name
+    libQnnHtp.so
+    libQnnSystem.so
+    libQnnHtpV68Stub.so
+    libQnnHtpV69Stub.so
+    libQnnHtpV73Stub.so
+    libQnnHtpV75Stub.so
+    libQnnHtpV79Stub.so
+    libQnnHtpV81Stub.so)
+    if(NOT EXISTS "${QNN_ANDROID_LIB_DIR}/${lib_name}")
+        message(FATAL_ERROR
+            "Could not locate required Android QNN library ${lib_name} in ${QNN_ANDROID_LIB_DIR}")
+    endif()
+    file(COPY ${QNN_ANDROID_LIB_DIR}/${lib_name}
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
+endforeach()
+
+foreach(hex_ver v68 v69 v73 v75 v79 v81)
+    string(TOUPPER "${hex_ver}" hex_ver_upper)
+    foreach(lib_name
+        libQnnHtp${hex_ver_upper}.so
+        libQnnHtp${hex_ver_upper}Skel.so)
+        first_existing_path(QNN_HEXAGON_LIB
+            ${QNN_RESOLVED_SDK_ROOT}/lib/hexagon-${hex_ver}/unsigned/${lib_name}
+            ${QNN_RESOLVED_SDK_ROOT}/lib/hexagon-${hex_ver}/${lib_name}
+            ${QNN_RESOLVED_SDK_ROOT}/hexagon-${hex_ver}/unsigned/${lib_name}
+        )
+        if(NOT QNN_HEXAGON_LIB)
+            file(GLOB_RECURSE QNN_HEXAGON_CANDIDATES
+                ${QNN_RESOLVED_SDK_ROOT}/*/${lib_name}
+                ${QNN_RESOLVED_SDK_ROOT}/*/*/${lib_name}
+                ${QNN_RESOLVED_SDK_ROOT}/*/*/*/${lib_name})
+            list(LENGTH QNN_HEXAGON_CANDIDATES QNN_HEXAGON_COUNT)
+            if(QNN_HEXAGON_COUNT GREATER 0)
+                list(GET QNN_HEXAGON_CANDIDATES 0 QNN_HEXAGON_LIB)
+            endif()
+        endif()
+        if(NOT QNN_HEXAGON_LIB)
+            message(FATAL_ERROR "Could not locate required Hexagon library ${lib_name}")
+        endif()
+        file(COPY ${QNN_HEXAGON_LIB}
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qnnlibs)
+    endforeach()
+endforeach()
 
 if(WIN32)
     set(PLATFORM_NAME "windows")
@@ -113,7 +210,7 @@ set(XTENSOR_USE_XSIMD ON)
 
 set(PACKAGE_INCLUDES
     ${MNN_ROOT_DIR}/include
-    ${QNN_SDK_ROOT}/include/QNN
+    ${QNN_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/cpp-httplib

--- a/app/src/main/cpp/build.sh
+++ b/app/src/main/cpp/build.sh
@@ -1,6 +1,6 @@
 set -e
 cmake --preset android-release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-cmake --build --preset android-release
+cmake --build --preset android-release --parallel "$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc || echo 2)"
 
 mkdir -p lib
 cp -r ./build/android/qnnlibs ../assets/

--- a/app/src/main/cpp/src/OpenAiCompat.hpp
+++ b/app/src/main/cpp/src/OpenAiCompat.hpp
@@ -1,0 +1,543 @@
+#ifndef OPENAI_COMPAT_HPP
+#define OPENAI_COMPAT_HPP
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <ctime>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "SDUtils.hpp"
+#include "httplib.h"
+#include "json.hpp"
+
+struct OpenAiHttpError : public std::runtime_error {
+  int status;
+  std::string type;
+  std::string param;
+
+  OpenAiHttpError(int s, std::string message,
+                  std::string error_type = "invalid_request_error",
+                  std::string error_param = "")
+      : std::runtime_error(std::move(message)),
+        status(s),
+        type(std::move(error_type)),
+        param(std::move(error_param)) {}
+};
+
+struct OpenAiRouteOptions {
+  bool fixed_canvas = false;
+  bool supports_img2img = false;
+  std::string api_key;
+  std::string active_model;
+};
+
+struct OpenAiPreparedRequest {
+  std::vector<nlohmann::json> items;
+};
+
+struct MultipartPart {
+  std::string name;
+  std::string filename;
+  std::string content_type;
+  std::string content;
+};
+
+inline void setOpenAiError(httplib::Response &res, int status,
+                           const std::string &message, const std::string &type,
+                           const std::string &param = "") {
+  nlohmann::json param_value = nullptr;
+  if (!param.empty()) {
+    param_value = param;
+  }
+  nlohmann::json err = {
+      {"error",
+       {{"message", message},
+        {"type", type},
+        {"param", param_value},
+        {"code", nullptr}}}};
+  res.status = status;
+  res.set_content(err.dump(), "application/json");
+}
+
+inline std::string trimAscii(std::string s) {
+  auto is_space = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  auto begin = std::find_if_not(s.begin(), s.end(), is_space);
+  auto end = std::find_if_not(s.rbegin(), s.rend(), is_space).base();
+  if (begin >= end) return "";
+  return std::string(begin, end);
+}
+
+inline std::string toLowerAscii(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char ch) { return std::tolower(ch); });
+  return s;
+}
+
+inline std::string unquote(std::string s) {
+  s = trimAscii(std::move(s));
+  if (s.size() >= 2 && s.front() == '"' && s.back() == '"') {
+    return s.substr(1, s.size() - 2);
+  }
+  return s;
+}
+
+inline int gcdPositive(int a, int b) {
+  while (b != 0) {
+    int t = b;
+    b = a % b;
+    a = t;
+  }
+  return std::max(a, 1);
+}
+
+inline std::string makeAspectRatioString(int width, int height) {
+  int d = gcdPositive(width, height);
+  return std::to_string(width / d) + ":" + std::to_string(height / d);
+}
+
+inline void requireOpenAiAuthorization(const httplib::Request &req,
+                                       const OpenAiRouteOptions &opts) {
+  if (opts.api_key.empty()) return;
+  if (!req.has_header("Authorization")) {
+    throw OpenAiHttpError(401, "Missing Authorization: Bearer <key> header",
+                          "authentication_error");
+  }
+
+  std::string auth = trimAscii(req.get_header_value("Authorization"));
+  if (auth.size() <= 7 ||
+      toLowerAscii(auth.substr(0, 7)) != std::string("bearer ")) {
+    throw OpenAiHttpError(401, "Invalid Authorization header",
+                          "authentication_error");
+  }
+
+  std::string token = auth.substr(7);
+  if (token != opts.api_key) {
+    throw OpenAiHttpError(401, "Invalid API key", "authentication_error");
+  }
+}
+
+inline void validateModelField(const nlohmann::json &json,
+                               const OpenAiRouteOptions &opts) {
+  if (!json.contains("model")) return;
+  std::string model = json["model"].get<std::string>();
+  if (model.empty() || opts.active_model.empty()) return;
+  if (model == opts.active_model || model == "default" ||
+      model == "local-dream")
+    return;
+  throw OpenAiHttpError(
+      400,
+      "This backend is already serving '" + opts.active_model +
+          "' and cannot switch to '" + model + "' via the OpenAI API",
+      "invalid_request_error", "model");
+}
+
+inline void validateKnownFields(const nlohmann::json &json,
+                                const std::set<std::string> &allowed) {
+  for (auto it = json.begin(); it != json.end(); ++it) {
+    if (allowed.count(it.key()) != 0) continue;
+    throw OpenAiHttpError(400, "Unsupported field '" + it.key() + "'",
+                          "invalid_request_error", it.key());
+  }
+}
+
+inline int parseStrictPositiveIntString(const std::string &value,
+                                        const std::string &field_name) {
+  try {
+    std::string trimmed = trimAscii(value);
+    size_t idx = 0;
+    int parsed = std::stoi(trimmed, &idx);
+    if (idx != trimmed.size() || parsed <= 0) throw std::invalid_argument("");
+    return parsed;
+  } catch (...) {
+    throw OpenAiHttpError(400, "Invalid '" + field_name + "' value",
+                          "invalid_request_error", field_name);
+  }
+}
+
+inline long long parseLongLongString(const std::string &value,
+                                     const std::string &field_name) {
+  try {
+    std::string trimmed = trimAscii(value);
+    size_t idx = 0;
+    long long parsed = std::stoll(trimmed, &idx);
+    if (idx != trimmed.size() || parsed < 0) throw std::invalid_argument("");
+    return parsed;
+  } catch (...) {
+    throw OpenAiHttpError(400, "Invalid '" + field_name + "' value",
+                          "invalid_request_error", field_name);
+  }
+}
+
+inline double parseDoubleString(const std::string &value,
+                                const std::string &field_name) {
+  try {
+    std::string trimmed = trimAscii(value);
+    size_t idx = 0;
+    double parsed = std::stod(trimmed, &idx);
+    if (idx != trimmed.size()) throw std::invalid_argument("");
+    return parsed;
+  } catch (...) {
+    throw OpenAiHttpError(400, "Invalid '" + field_name + "' value",
+                          "invalid_request_error", field_name);
+  }
+}
+
+inline bool parseBoolString(const std::string &value,
+                            const std::string &field_name) {
+  std::string trimmed = toLowerAscii(trimAscii(value));
+  if (trimmed == "true" || trimmed == "1") return true;
+  if (trimmed == "false" || trimmed == "0") return false;
+  throw OpenAiHttpError(400, "Invalid '" + field_name + "' value",
+                        "invalid_request_error", field_name);
+}
+
+inline void applySizeField(const std::string &size,
+                           const OpenAiRouteOptions &opts,
+                           nlohmann::json &internal_json) {
+  std::string trimmed = trimAscii(size);
+  auto x_pos = trimmed.find('x');
+  if (x_pos == std::string::npos) x_pos = trimmed.find('X');
+  if (x_pos == std::string::npos || x_pos == 0 || x_pos + 1 >= trimmed.size()) {
+    throw OpenAiHttpError(400, "Invalid 'size' value; expected WIDTHxHEIGHT",
+                          "invalid_request_error", "size");
+  }
+
+  int width = parseStrictPositiveIntString(trimmed.substr(0, x_pos), "size");
+  int height =
+      parseStrictPositiveIntString(trimmed.substr(x_pos + 1), "size");
+  if (width % 8 != 0 || height % 8 != 0) {
+    throw OpenAiHttpError(400, "Image size must be a multiple of 8",
+                          "invalid_request_error", "size");
+  }
+
+  if (opts.fixed_canvas) {
+    if (width != height) {
+      internal_json["aspect_ratio"] = makeAspectRatioString(width, height);
+    }
+  } else {
+    internal_json["width"] = width;
+    internal_json["height"] = height;
+  }
+}
+
+inline int parseImageCount(const nlohmann::json &json) {
+  int n = json.value("n", 1);
+  if (n <= 0) {
+    throw OpenAiHttpError(400, "'n' must be greater than 0",
+                          "invalid_request_error", "n");
+  }
+  return n;
+}
+
+inline nlohmann::json buildInternalGenerationJson(
+    const nlohmann::json &json, const OpenAiRouteOptions &opts) {
+  if (!json.is_object()) {
+    throw OpenAiHttpError(400, "Request body must be a JSON object",
+                          "invalid_request_error");
+  }
+
+  static const std::set<std::string> kAllowedFields = {
+      "prompt",         "model",        "n",
+      "size",           "response_format",
+      "user",           "negative_prompt",
+      "seed",           "steps",        "cfg",
+      "scheduler",      "use_opencl",   "denoise_strength",
+      "show_diffusion_process",         "show_diffusion_stride",
+      "aspect_ratio"};
+  validateKnownFields(json, kAllowedFields);
+  validateModelField(json, opts);
+
+  std::string prompt = json.value("prompt", std::string());
+  if (prompt.empty()) {
+    throw OpenAiHttpError(400, "Missing 'prompt'", "invalid_request_error",
+                          "prompt");
+  }
+
+  std::string response_format = json.value("response_format", "b64_json");
+  if (response_format != "b64_json") {
+    throw OpenAiHttpError(400, "Only response_format='b64_json' is supported",
+                          "invalid_request_error", "response_format");
+  }
+
+  nlohmann::json internal_json = {{"prompt", prompt},
+                                  {"output_format", "png"},
+                                  {"show_diffusion_process", false}};
+  if (json.contains("negative_prompt")) {
+    internal_json["negative_prompt"] = json["negative_prompt"];
+  }
+  if (json.contains("steps")) internal_json["steps"] = json["steps"];
+  if (json.contains("cfg")) internal_json["cfg"] = json["cfg"];
+  if (json.contains("scheduler"))
+    internal_json["scheduler"] = json["scheduler"];
+  if (json.contains("use_opencl"))
+    internal_json["use_opencl"] = json["use_opencl"];
+  if (json.contains("denoise_strength"))
+    internal_json["denoise_strength"] = json["denoise_strength"];
+  if (json.contains("show_diffusion_stride"))
+    internal_json["show_diffusion_stride"] = json["show_diffusion_stride"];
+  if (json.contains("aspect_ratio") && !json.contains("size")) {
+    internal_json["aspect_ratio"] = json["aspect_ratio"];
+  }
+  if (json.contains("size")) {
+    applySizeField(json["size"].get<std::string>(), opts, internal_json);
+  }
+  return internal_json;
+}
+
+inline OpenAiPreparedRequest parseOpenAiGenerationRequest(
+    const nlohmann::json &json, const OpenAiRouteOptions &opts) {
+  int count = parseImageCount(json);
+  nlohmann::json internal_base = buildInternalGenerationJson(json, opts);
+
+  bool has_seed = json.contains("seed");
+  long long base_seed = static_cast<long long>(
+      std::chrono::high_resolution_clock::now().time_since_epoch().count());
+  if (has_seed) {
+    base_seed = json["seed"].get<long long>();
+    if (base_seed < 0) {
+      throw OpenAiHttpError(400, "Invalid 'seed' value",
+                            "invalid_request_error", "seed");
+    }
+  }
+
+  OpenAiPreparedRequest prepared;
+  prepared.items.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    auto item = internal_base;
+    item["seed"] = base_seed + i;
+    prepared.items.push_back(std::move(item));
+  }
+  return prepared;
+}
+
+inline std::string extractBoundary(const httplib::Request &req) {
+  if (!req.has_header("Content-Type")) {
+    throw OpenAiHttpError(400, "Missing Content-Type header",
+                          "invalid_request_error");
+  }
+  std::string content_type = req.get_header_value("Content-Type");
+  std::string lower = toLowerAscii(content_type);
+  if (lower.find("multipart/form-data") == std::string::npos) {
+    throw OpenAiHttpError(400, "Expected multipart/form-data request",
+                          "invalid_request_error");
+  }
+
+  auto boundary_pos = lower.find("boundary=");
+  if (boundary_pos == std::string::npos) {
+    throw OpenAiHttpError(400, "Missing multipart boundary",
+                          "invalid_request_error");
+  }
+  std::string boundary = content_type.substr(boundary_pos + 9);
+  auto semicolon = boundary.find(';');
+  if (semicolon != std::string::npos) boundary = boundary.substr(0, semicolon);
+  boundary = unquote(boundary);
+  if (boundary.empty()) {
+    throw OpenAiHttpError(400, "Invalid multipart boundary",
+                          "invalid_request_error");
+  }
+  return boundary;
+}
+
+inline MultipartPart parseMultipartPart(const std::string &header_block,
+                                        std::string content) {
+  MultipartPart part;
+  size_t line_start = 0;
+  while (line_start < header_block.size()) {
+    size_t line_end = header_block.find("\r\n", line_start);
+    if (line_end == std::string::npos) line_end = header_block.size();
+    std::string line = header_block.substr(line_start, line_end - line_start);
+    auto colon = line.find(':');
+    if (colon != std::string::npos) {
+      std::string key = toLowerAscii(trimAscii(line.substr(0, colon)));
+      std::string value = trimAscii(line.substr(colon + 1));
+      if (key == "content-type") {
+        part.content_type = value;
+      } else if (key == "content-disposition") {
+        size_t seg_start = 0;
+        while (seg_start < value.size()) {
+          size_t seg_end = value.find(';', seg_start);
+          if (seg_end == std::string::npos) seg_end = value.size();
+          std::string seg = trimAscii(value.substr(seg_start, seg_end - seg_start));
+          auto eq = seg.find('=');
+          if (eq != std::string::npos) {
+            std::string attr = toLowerAscii(trimAscii(seg.substr(0, eq)));
+            std::string attr_val = unquote(seg.substr(eq + 1));
+            if (attr == "name") part.name = attr_val;
+            if (attr == "filename") part.filename = attr_val;
+          }
+          seg_start = seg_end + 1;
+        }
+      }
+    }
+    line_start = line_end + 2;
+  }
+  part.content = std::move(content);
+  return part;
+}
+
+inline std::vector<MultipartPart> parseMultipartFormData(
+    const httplib::Request &req) {
+  std::string boundary = extractBoundary(req);
+  std::string delimiter = "--" + boundary;
+  std::string search = "\r\n" + delimiter;
+  const std::string &body = req.body;
+  if (body.compare(0, delimiter.size(), delimiter) != 0) {
+    throw OpenAiHttpError(400, "Malformed multipart body",
+                          "invalid_request_error");
+  }
+
+  std::vector<MultipartPart> parts;
+  size_t pos = 0;
+  while (true) {
+    if (body.compare(pos, delimiter.size(), delimiter) != 0) {
+      throw OpenAiHttpError(400, "Malformed multipart boundary",
+                            "invalid_request_error");
+    }
+    pos += delimiter.size();
+    if (body.compare(pos, 2, "--") == 0) break;
+    if (body.compare(pos, 2, "\r\n") != 0) {
+      throw OpenAiHttpError(400, "Malformed multipart separator",
+                            "invalid_request_error");
+    }
+    pos += 2;
+
+    size_t header_end = body.find("\r\n\r\n", pos);
+    if (header_end == std::string::npos) {
+      throw OpenAiHttpError(400, "Malformed multipart headers",
+                            "invalid_request_error");
+    }
+    std::string header_block = body.substr(pos, header_end - pos);
+    pos = header_end + 4;
+
+    size_t next_delim = body.find(search, pos);
+    if (next_delim == std::string::npos) {
+      throw OpenAiHttpError(400, "Malformed multipart content",
+                            "invalid_request_error");
+    }
+    std::string content = body.substr(pos, next_delim - pos);
+    pos = next_delim + 2;
+
+    MultipartPart part = parseMultipartPart(header_block, std::move(content));
+    if (part.name.empty()) {
+      throw OpenAiHttpError(400, "Multipart part missing name",
+                            "invalid_request_error");
+    }
+    parts.push_back(std::move(part));
+  }
+
+  return parts;
+}
+
+inline bool extractMultipartFormDataFromRequest(
+    const httplib::Request &req, std::map<std::string, std::string> &fields,
+    std::map<std::string, MultipartPart> &files) {
+  bool found_any = false;
+
+  for (const auto &entry : req.files) {
+    if (entry.second.filename.empty()) {
+      fields[entry.first] = entry.second.content;
+      found_any = true;
+      continue;
+    }
+
+    MultipartPart part;
+    part.name = entry.second.name.empty() ? entry.first : entry.second.name;
+    part.filename = entry.second.filename;
+    part.content_type = entry.second.content_type;
+    part.content = entry.second.content;
+    files[entry.first] = std::move(part);
+    found_any = true;
+  }
+
+  for (const auto &entry : req.params) {
+    if (fields.count(entry.first) == 0) {
+      fields[entry.first] = entry.second;
+      found_any = true;
+    }
+  }
+
+  return found_any;
+}
+
+inline nlohmann::json multipartFieldsToJson(
+    const std::map<std::string, std::string> &fields) {
+  nlohmann::json json = nlohmann::json::object();
+  for (const auto &[key, value] : fields) {
+    if (key == "n" || key == "steps" || key == "show_diffusion_stride") {
+      json[key] = parseStrictPositiveIntString(value, key);
+    } else if (key == "seed") {
+      json[key] = parseLongLongString(value, key);
+    } else if (key == "cfg" || key == "denoise_strength") {
+      json[key] = parseDoubleString(value, key);
+    } else if (key == "use_opencl" || key == "show_diffusion_process") {
+      json[key] = parseBoolString(value, key);
+    } else {
+      json[key] = value;
+    }
+  }
+  return json;
+}
+
+inline OpenAiPreparedRequest parseOpenAiEditRequest(
+    const httplib::Request &req, const OpenAiRouteOptions &opts) {
+  if (!opts.supports_img2img) {
+    throw OpenAiHttpError(
+        400,
+        "Image edits are unavailable because this backend was started without img2img support",
+        "invalid_request_error");
+  }
+
+  std::map<std::string, std::string> fields;
+  std::map<std::string, MultipartPart> files;
+  if (!extractMultipartFormDataFromRequest(req, fields, files)) {
+    std::vector<MultipartPart> parts = parseMultipartFormData(req);
+    for (auto &part : parts) {
+      if (part.filename.empty() && part.name != "image" &&
+          part.name != "mask") {
+        fields[part.name] = part.content;
+      } else {
+        files[part.name] = std::move(part);
+      }
+    }
+  }
+
+  if (files.count("image") == 0 || files["image"].content.empty()) {
+    throw OpenAiHttpError(400, "Missing 'image' file", "invalid_request_error",
+                          "image");
+  }
+  if (fields.count("prompt") == 0 || trimAscii(fields["prompt"]).empty()) {
+    throw OpenAiHttpError(400, "Missing 'prompt'", "invalid_request_error",
+                          "prompt");
+  }
+
+  nlohmann::json json = multipartFieldsToJson(fields);
+  OpenAiPreparedRequest prepared = parseOpenAiGenerationRequest(json, opts);
+  std::string image_b64 = base64_encode(files["image"].content);
+  std::string mask_b64;
+  bool has_mask = files.count("mask") != 0 && !files["mask"].content.empty();
+  if (has_mask) mask_b64 = base64_encode(files["mask"].content);
+
+  for (auto &item : prepared.items) {
+    item["image"] = image_b64;
+    if (has_mask) item["mask"] = mask_b64;
+  }
+  return prepared;
+}
+
+inline nlohmann::json buildOpenAiImagesResponse(
+    const std::vector<std::string> &images_b64) {
+  nlohmann::json data = nlohmann::json::array();
+  for (const auto &image : images_b64) {
+    data.push_back({{"b64_json", image}});
+  }
+  return {{"created", static_cast<long long>(std::time(nullptr))},
+          {"data", std::move(data)}};
+}
+
+#endif  // OPENAI_COMPAT_HPP

--- a/app/src/main/cpp/src/main.cpp
+++ b/app/src/main/cpp/src/main.cpp
@@ -10,6 +10,7 @@
 
 #include "Config.hpp"
 #include "MnnUtils.hpp"
+#include "OpenAiCompat.hpp"
 #include "Pipeline.hpp"
 #include "PipelineAnima.hpp"
 #include "PipelineSd15Cpu.hpp"
@@ -63,6 +64,8 @@ struct ServerOptions {
   bool no_img2img = false;  // skip the VAE encoder entirely
   bool lowram = false;
   bool anima_seq_dit = false;  // (anima+lowram) never co-resident DiT halves
+  bool openai_api_enabled = true;
+  std::string api_key;
   bool upscaler_mode = false;
   bool convert_mode = false;
   bool convert_clip_skip_2 = false;
@@ -105,6 +108,9 @@ static void showHelp() {
          "  --lowram               (sdxl/anima) load/release models per stage\n"
          "  --anima_seq_dit        (anima+lowram) never keep both DiT halves "
          "resident; for 12GB devices\n"
+         "  --no_openai_api        Disable OpenAI-compatible image routes\n"
+         "  --api_key <key>        Require Bearer auth for OpenAI-compatible "
+         "routes\n"
          "  --clip_skip_2          (convert) export CLIP with skip 2\n"
          "  --log_level <n>        QNN log level\n"
          "  --version              Print QNN SDK build id\n"
@@ -136,6 +142,8 @@ static ServerOptions processCommandLine(int argc, char **argv) {
     OPT_UPSCALER_MODE,
     OPT_LOWRAM,
     OPT_ANIMA_SEQ_DIT,
+    OPT_NO_OPENAI_API,
+    OPT_API_KEY,
     OPT_LOG_LEVEL
   };
   static struct pal::Option s_longOptions[] = {
@@ -155,6 +163,8 @@ static ServerOptions processCommandLine(int argc, char **argv) {
       {"upscaler_mode", pal::no_argument, NULL, OPT_UPSCALER_MODE},
       {"lowram", pal::no_argument, NULL, OPT_LOWRAM},
       {"anima_seq_dit", pal::no_argument, NULL, OPT_ANIMA_SEQ_DIT},
+      {"no_openai_api", pal::no_argument, NULL, OPT_NO_OPENAI_API},
+      {"api_key", pal::required_argument, NULL, OPT_API_KEY},
       {"log_level", pal::required_argument, NULL, OPT_LOG_LEVEL},
       {NULL, 0, NULL, 0}};
 
@@ -215,6 +225,12 @@ static ServerOptions processCommandLine(int argc, char **argv) {
         break;
       case OPT_ANIMA_SEQ_DIT:
         opts.anima_seq_dit = true;
+        break;
+      case OPT_NO_OPENAI_API:
+        opts.openai_api_enabled = false;
+        break;
+      case OPT_API_KEY:
+        opts.api_key = pal::g_optArg;
         break;
       case OPT_LOG_LEVEL:
         logLevel = sample_app::parseLogLevel(pal::g_optArg);
@@ -386,6 +402,13 @@ static std::string encodeResultImage(const GenerationResult &result,
 // new request arriving while an aborted one is still winding down).
 static std::mutex g_generation_mutex;
 
+static GenerationResult runGenerationLocked(Pipeline *pipeline,
+                                            GenerationRequest &req,
+                                            const ProgressCallback &cb) {
+  std::lock_guard<std::mutex> generation_lock(g_generation_mutex);
+  return pipeline->generate(req, cb);
+}
+
 static void registerGenerateEndpoint(httplib::Server &svr, Pipeline *pipeline) {
   svr.Post("/generate", [pipeline](const httplib::Request &request,
                                    httplib::Response &res) {
@@ -411,9 +434,9 @@ static void registerGenerateEndpoint(httplib::Server &svr, Pipeline *pipeline) {
           "text/event-stream",
           [pipeline, req](intptr_t, httplib::DataSink &sink) -> bool {
             try {
-              std::lock_guard<std::mutex> generation_lock(g_generation_mutex);
-              auto result = pipeline->generate(
-                  *req, [&sink, &req](int s, int t, const std::string &img) {
+              auto result = runGenerationLocked(
+                  pipeline, *req, [&sink, &req](int s, int t,
+                                                const std::string &img) {
                     nlohmann::json p = {
                         {"type", "progress"}, {"step", s}, {"total_steps", t}};
                     if (!img.empty()) {
@@ -493,6 +516,94 @@ static void registerGenerateEndpoint(httplib::Server &svr, Pipeline *pipeline) {
       res.set_content(err.dump(), "application/json");
     }
   });
+}
+
+static void registerOpenAiImageEndpoints(httplib::Server &svr,
+                                         Pipeline *pipeline,
+                                         const ServerOptions &opts) {
+  if (!opts.openai_api_enabled) return;
+
+  OpenAiRouteOptions route_opts = {
+      pipeline->isSdxl() || pipeline->isAnima(),
+      pipeline->supportsImg2Img(),
+      opts.api_key,
+      std::filesystem::path(opts.model_dir).filename().string(),
+  };
+
+  auto handle_openai_request =
+      [pipeline](const OpenAiPreparedRequest &prepared, httplib::Response &res) {
+        std::vector<std::string> images_b64;
+        images_b64.reserve(prepared.items.size());
+        for (const auto &item_json : prepared.items) {
+          GenerationRequest req = parseGenerationRequest(
+              item_json, pipeline->isSdxl(), pipeline->isAnima(),
+              pipeline->supportsImg2Img(), pipeline->supportsUltrafix());
+          auto result = runGenerationLocked(
+              pipeline, req,
+              [](int, int, const std::string &) {
+                // OpenAI-compatible routes return only the final image.
+              });
+          images_b64.push_back(encodeResultImage(result, "png"));
+        }
+        res.status = 200;
+        res.set_content(buildOpenAiImagesResponse(images_b64).dump(),
+                        "application/json");
+      };
+
+  svr.Post("/v1/images/generations",
+           [route_opts, handle_openai_request](const httplib::Request &request,
+                                               httplib::Response &res) {
+             try {
+               requireOpenAiAuthorization(request, route_opts);
+               auto json = nlohmann::json::parse(request.body);
+               auto prepared = parseOpenAiGenerationRequest(json, route_opts);
+               handle_openai_request(prepared, res);
+             } catch (const OpenAiHttpError &e) {
+               setOpenAiError(res, e.status, e.what(), e.type, e.param);
+             } catch (const nlohmann::json::parse_error &e) {
+               setOpenAiError(res, 400,
+                              "Invalid JSON: " + std::string(e.what()),
+                              "invalid_request_error");
+             } catch (const nlohmann::json::exception &e) {
+               setOpenAiError(res, 400,
+                              "Invalid request field type: " +
+                                  std::string(e.what()),
+                              "invalid_request_error");
+             } catch (const std::invalid_argument &e) {
+               setOpenAiError(res, 400,
+                              "Invalid Arg: " + std::string(e.what()),
+                              "invalid_request_error");
+             } catch (const std::exception &e) {
+               setOpenAiError(res, 500,
+                              "Server Err: " + std::string(e.what()),
+                              "server_error");
+             }
+           });
+
+  svr.Post("/v1/images/edits",
+           [route_opts, handle_openai_request](const httplib::Request &request,
+                                               httplib::Response &res) {
+             try {
+               requireOpenAiAuthorization(request, route_opts);
+               auto prepared = parseOpenAiEditRequest(request, route_opts);
+               handle_openai_request(prepared, res);
+             } catch (const OpenAiHttpError &e) {
+               setOpenAiError(res, e.status, e.what(), e.type, e.param);
+             } catch (const nlohmann::json::exception &e) {
+               setOpenAiError(res, 400,
+                              "Invalid request field type: " +
+                                  std::string(e.what()),
+                              "invalid_request_error");
+             } catch (const std::invalid_argument &e) {
+               setOpenAiError(res, 400,
+                              "Invalid Arg: " + std::string(e.what()),
+                              "invalid_request_error");
+             } catch (const std::exception &e) {
+               setOpenAiError(res, 500,
+                              "Server Err: " + std::string(e.what()),
+                              "server_error");
+             }
+           });
 }
 
 // Binary protocol upscale endpoint - optimized for performance.
@@ -787,6 +898,7 @@ int main(int argc, char **argv) {
   });
 
   if (pipeline) registerGenerateEndpoint(svr, pipeline.get());
+  if (pipeline) registerOpenAiImageEndpoints(svr, pipeline.get(), opts);
   registerUpscaleEndpoint(svr);
   if (text_encoder) registerTokenizeEndpoint(svr, text_encoder.get());
 

--- a/app/src/main/java/io/github/xororz/localdream/service/BackendService.kt
+++ b/app/src/main/java/io/github/xororz/localdream/service/BackendService.kt
@@ -381,6 +381,8 @@ class BackendService : Service() {
             val preferences = this.getSharedPreferences("app_prefs", MODE_PRIVATE)
             val useImg2img = preferences.getBoolean("use_img2img", true)
             val listenOnAll = preferences.getBoolean("listen_on_all_addresses", false)
+            val openAiApiEnabled = preferences.getBoolean("enable_openai_api", true)
+            val openAiApiKey = preferences.getString("openai_api_key", "")?.trim().orEmpty()
 
             val command = mutableListOf(
                 executableFile.absolutePath,
@@ -444,6 +446,12 @@ class BackendService : Service() {
             }
             if (listenOnAll) {
                 command += "--listen_all"
+            }
+            if (!openAiApiEnabled) {
+                command += "--no_openai_api"
+            }
+            if (openAiApiKey.isNotEmpty()) {
+                command += listOf("--api_key", openAiApiKey)
             }
             val env = mutableMapOf<String, String>()
 

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelListScreen.kt
@@ -1405,6 +1405,22 @@ fun ModelListScreen(navController: NavController, modifier: Modifier = Modifier)
                                         preferences.getBoolean("listen_on_all_addresses", false),
                                     )
                                 }
+                                var enableOpenAiApi by remember {
+                                    mutableStateOf(
+                                        preferences.getBoolean("enable_openai_api", true).also {
+                                            if (!preferences.contains("enable_openai_api")) {
+                                                preferences.edit {
+                                                    putBoolean("enable_openai_api", true)
+                                                }
+                                            }
+                                        },
+                                    )
+                                }
+                                var openAiApiKey by remember {
+                                    mutableStateOf(
+                                        preferences.getString("openai_api_key", "").orEmpty(),
+                                    )
+                                }
                                 var enableTagAutocomplete by remember {
                                     mutableStateOf(
                                         preferences.getBoolean("enable_tag_autocomplete", true)
@@ -1765,6 +1781,74 @@ fun ModelListScreen(navController: NavController, modifier: Modifier = Modifier)
                                         }
                                     },
                                 )
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                )
+                                SwitchSettingRow(
+                                    title = stringResource(R.string.openai_compat_api),
+                                    description = stringResource(R.string.openai_compat_api_hint),
+                                    checked = enableOpenAiApi,
+                                    onCheckedChange = {
+                                        enableOpenAiApi = it
+                                        preferences.edit { putBoolean("enable_openai_api", it) }
+                                    },
+                                )
+                                AnimatedVisibility(visible = enableOpenAiApi) {
+                                    Column {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                        )
+                                        Column(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp),
+                                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                                        ) {
+                                            Text(
+                                                text = stringResource(R.string.openai_api_key),
+                                                style = MaterialTheme.typography.titleSmall,
+                                            )
+                                            Text(
+                                                text = stringResource(
+                                                    R.string.openai_api_key_hint,
+                                                ),
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                            OutlinedTextField(
+                                                value = openAiApiKey,
+                                                onValueChange = {
+                                                    openAiApiKey = it
+                                                    preferences.edit {
+                                                        putString("openai_api_key", it)
+                                                    }
+                                                },
+                                                label = {
+                                                    Text(
+                                                        stringResource(R.string.openai_api_key),
+                                                    )
+                                                },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                singleLine = true,
+                                            )
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.End,
+                                            ) {
+                                                TextButton(
+                                                    onClick = {
+                                                        openAiApiKey = ""
+                                                        preferences.edit {
+                                                            putString("openai_api_key", "")
+                                                        }
+                                                    },
+                                                ) {
+                                                    Text(stringResource(R.string.clear))
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,6 +11,10 @@
     <string name="capture_logs_hint">モデル実行中にアプリのログを収集し、終了後に表示します</string>
     <string name="listen_on_all_addresses">LAN からのアクセスを許可</string>
     <string name="listen_on_all_addresses_hint">同じネットワーク上の他のデバイスからバックエンド（ポート 8081）にアクセスできるようにします。オフの場合はローカルのみ。</string>
+    <string name="openai_compat_api">OpenAI 互換 API</string>
+    <string name="openai_compat_api_hint">既存のバックエンド API を残したまま、`/v1/images/generations` と `/v1/images/edits` を公開します。</string>
+    <string name="openai_api_key">OpenAI API キー</string>
+    <string name="openai_api_key_hint">任意です。空欄なら認証不要、設定すると OpenAI 互換ルートで `Authorization: Bearer &lt;key&gt;` が必須になります。</string>
     <string name="tag_autocomplete">タグ補完</string>
     <string name="tag_autocomplete_hint">プロンプト入力中にタグを補完・修正します</string>
     <string name="tag_alias_label">別名</string>
@@ -67,6 +71,7 @@
     <string name="confirm">決定</string>
     <string name="cancel">取り消す</string>
     <string name="save">保存</string>
+    <string name="clear">クリア</string>
     <string name="back">戻る</string>
     <string name="close">閉じる</string>
     <string name="delete">削除</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -11,6 +11,10 @@
     <string name="capture_logs_hint">运行模型时收集应用日志，退出后展示</string>
     <string name="listen_on_all_addresses">允许局域网访问</string>
     <string name="listen_on_all_addresses_hint">允许同一网络下的其他设备访问后端（端口 8081）。关闭则只接受本机访问。</string>
+    <string name="openai_compat_api">OpenAI 兼容 API</string>
+    <string name="openai_compat_api_hint">在保留现有后端接口的同时，额外开放 `/v1/images/generations` 和 `/v1/images/edits`。</string>
+    <string name="openai_api_key">OpenAI API Key</string>
+    <string name="openai_api_key_hint">可选。留空则无需认证；填写后，OpenAI 兼容路由需要携带 `Authorization: Bearer &lt;key&gt;`。</string>
     <string name="tag_autocomplete">Tag 联想</string>
     <string name="tag_autocomplete_hint">输入提示词时联想并纠正 tag</string>
     <string name="tag_alias_label">别名</string>
@@ -67,6 +71,7 @@
     <string name="confirm">确定</string>
     <string name="cancel">取消</string>
     <string name="save">保存</string>
+    <string name="clear">清空</string>
     <string name="back">返回</string>
     <string name="close">关闭</string>
     <string name="delete">删除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="capture_logs_hint">Collect app logs while a model is running, then show them after you exit</string>
     <string name="listen_on_all_addresses">Allow LAN access</string>
     <string name="listen_on_all_addresses_hint">Let other devices on the same network reach the backend (port 8081). Off = local only.</string>
+    <string name="openai_compat_api">OpenAI-compatible API</string>
+    <string name="openai_compat_api_hint">Expose `/v1/images/generations` and `/v1/images/edits` alongside the existing backend API.</string>
+    <string name="openai_api_key">OpenAI API key</string>
+    <string name="openai_api_key_hint">Optional. Leave blank for anonymous access, or set a key to require `Authorization: Bearer &lt;key&gt;` on the OpenAI-compatible routes.</string>
     <string name="tag_autocomplete">Tag autocomplete</string>
     <string name="tag_autocomplete_hint">Suggest and correct tags while you type prompts</string>
     <string name="tag_alias_label">Alias</string>
@@ -69,6 +73,7 @@
     <string name="confirm">Confirm</string>
     <string name="cancel">Cancel</string>
     <string name="save">Save</string>
+    <string name="clear">Clear</string>
     <string name="back">Back</string>
     <string name="close">Close</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
Add OpenAI-compatible image API and CI build workflow

Support OpenAI-compatible API end-port both `/v1/images/generations` `/v1/images/edits`

example (All Support Config):

`/v1/images/generations`
~~~bash
curl -sS http://127.0.0.1:8081/v1/images/generations \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer <API-KEY>' \
    -d '{
      "model": "local-dream",
      "prompt": "a cat, warm sun",
      "negative_prompt": "blurry, low quality, deformed, extra limbs",
      "n": 1,
      "size": "1024x1024",
      "seed": 12345,
      "steps": 20,
      "cfg": 7.5,
      "scheduler": "dpm",
      "use_opencl": false,
      "denoise_strength": 0.6,
      "show_diffusion_process": false,
      "show_diffusion_stride": 2,
      "response_format": "b64_json",
      "user": "demo-client"
    }'
~~~

`/v1/images/edits`
~~~bash
curl -sS http://127.0.0.1:8081/v1/images/edits \
    -H 'Authorization: Bearer <API-KEY>' \
    -F 'image=@/path/to/input.png;type=image/png' \
    -F 'mask=@/path/to/mask.png;type=image/png' \
    -F 'model=local-dream' \
    -F 'prompt=a cat, warm sun' \
    -F 'negative_prompt=blurry, low quality, deformed, extra limbs' \
    -F 'n=1' \
    -F 'size=1024x1024' \
    -F 'seed=12345' \
    -F 'steps=20' \
    -F 'cfg=7.5' \
    -F 'scheduler=dpm' \
    -F 'use_opencl=false' \
    -F 'denoise_strength=0.55' \
    -F 'show_diffusion_process=false' \
    -F 'show_diffusion_stride=2' \
    -F 'response_format=b64_json' \
    -F 'user=demo-client'
~~~

If enable the API key, you should add this for then
`-H 'Authorization: Bearer Yourkey'`

The api will return:
~~~json
{
    "created": 1234567890,
    "data": [
      {
        "b64_json": "......"
      }
    ]
}
~~~