### PR TITLE
fix: resolve edge-misalignment seams when stitching inpaint patch on save

### DIFF
--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
@@ -1086,8 +1086,58 @@ fun ModelRunScreen(
                         val mutableOriginal =
                             originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
 
-                        val rectW = snapshotCropRect!!.width()
-                        val rectH = snapshotCropRect!!.height()
+                        var rectW = snapshotCropRect!!.width()
+                        var rectH = snapshotCropRect!!.height()
+
+                        var finalLeft = snapshotCropRect!!.left
+                        var finalTop = snapshotCropRect!!.top
+
+                        // Convert 2dp rounding error margin to physical pixels based on device density
+                        val displayMetrics = context.resources.displayMetrics
+                        val density = displayMetrics.density
+                        val tolerance = (2f * density).roundToInt().coerceAtLeast(1)
+
+                        // Vertical axis adjustment (Top / Bottom)
+                        val matchesFullHeight = Math.abs(rectH - originalBitmap.height) <= tolerance
+
+                        if (matchesFullHeight) {
+                            // If the patch spans the full height, force it to take the EXACT
+                            // maximum height of the original image to prevent vertical compression.
+                            rectH = originalBitmap.height
+                            finalTop = 0
+                        } else {
+                            // Standard edge-snapping for localized vertical patches
+                            val isBottomEdge = snapshotCropRect!!.bottom >= (originalBitmap.height - tolerance)
+                            val isTopEdge = snapshotCropRect!!.top <= tolerance
+
+                            if (isBottomEdge) {
+                                finalTop = originalBitmap.height - rectH
+                            } else if (isTopEdge) {
+                                finalTop = 0
+                            }
+                        }
+
+                        // Horizontal axis adjustment (Left / Right)
+                        val matchesFullWidth = Math.abs(rectW - originalBitmap.width) <= tolerance
+
+                        if (matchesFullWidth) {
+                            // If the patch spans the full width, force it to take the EXACT
+                            // maximum width of the original image to prevent horizontal compression.
+                            rectW = originalBitmap.width
+                            finalLeft = 0
+                        } else {
+                            // Standard edge-snapping for localized horizontal patches
+                            val isRightEdge = snapshotCropRect!!.right >= (originalBitmap.width - tolerance)
+                            val isLeftEdge = snapshotCropRect!!.left <= tolerance
+
+                            if (isRightEdge) {
+                                finalLeft = originalBitmap.width - rectW
+                            } else if (isLeftEdge) {
+                                finalLeft = 0
+                            }
+                        }
+
+                        // Scale the patch to the mathematically corrected dimensions
                         val resizedPatch = bitmap.scale(rectW, rectH)
 
                         // Feather-blend along the mask instead of pasting the
@@ -1098,8 +1148,8 @@ fun ModelRunScreen(
                             target = mutableOriginal,
                             patch = resizedPatch,
                             mask = snapshotMaskBitmap,
-                            left = snapshotCropRect!!.left,
-                            top = snapshotCropRect!!.top,
+                            left = finalLeft,
+                            top = finalTop,
                         )
 
                         saveImage(


### PR DESCRIPTION
### Summary
This PR fixes a bug where a thin 1-4px layout seam of the original image would appear at the canvas borders of the stitched inpaint patch on save.

### Technical Details
* **The Problem**: Fractional rounding discrepancies between Jetpack Compose screen coordinates (`Float`/`dp`) and bitmap dimensions (`Int`) caused `snapshotCropRect` to drift by a few physical pixels, leading to compression and layout displacement artifacts.
* **Density Tolerance & Snapping**: Implemented a dynamic tolerance window based on a `2dp` margin (`context.resources.displayMetrics.density`) to snap localized patch coordinates directly to absolute image boundaries.
* **Full-Axis Override**: Added independent logic to detect when the patch covers the entire width or height of the asset. In these cases, it overrides the crop dimensions with the exact original bitmap size to prevent destructive scaling compression.

### Testing
Successfully verified against full-image configurations, vertical/horizontal edge панорамы, and isolated corner selections. All boundary artifact strips are resolved.
