### PR TITLE
feat: add canvas drawing for Img2Img source images

### DIFF
--- a/app/src/androidTest/java/io/github/xororz/localdream/ui/screens/DrawingRegressionTest.kt
+++ b/app/src/androidTest/java/io/github/xororz/localdream/ui/screens/DrawingRegressionTest.kt
@@ -1,0 +1,205 @@
+package io.github.xororz.localdream.ui.screens
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.get
+import androidx.core.graphics.set
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DrawingRegressionTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun snappedCropsRoundTripWithoutDisplacingPixels() {
+        val original = createBitmap(512, 512)
+        val pixels = IntArray(512 * 512) { index ->
+            android.graphics.Color.rgb(index % 251, (index / 512) % 251, index % 239)
+        }
+        original.setPixels(pixels, 0, 512, 0, 0, 512, 512)
+        val selections = listOf(
+            Rect(3, 2, 259, 258), // top/left
+            Rect(253, 254, 509, 510), // bottom/right
+            Rect(0, 0, 511, 511), // full image rounded down
+            Rect(128, 1, 384, 511), // full height only
+            Rect(1, 128, 511, 384), // full width only
+            Rect(100, 100, 356, 356), // interior
+        )
+        selections.forEach { selection ->
+            val crop = snapInpaintCropRect(selection, 512, 512, 6)
+            val patch = Bitmap.createBitmap(original, crop.left, crop.top, crop.width(), crop.height())
+            val result = original.copy(Bitmap.Config.ARGB_8888, true)
+            drawInpaintPatch(result, patch, null, crop.left, crop.top)
+            val actual = IntArray(pixels.size)
+            result.getPixels(actual, 0, 512, 0, 0, 512, 512)
+            assertArrayEquals("Pixel alignment for $selection", pixels, actual)
+        }
+        assertEquals(Rect(0, 0, 512, 512), snapInpaintCropRect(Rect(0, 0, 511, 511), 512, 512, 6))
+        assertEquals(Rect(100, 100, 356, 356), snapInpaintCropRect(Rect(100, 100, 356, 356), 512, 512, 6))
+    }
+
+    @Test
+    fun exportedStrokesMapThroughLetterboxingToOriginalPixels() {
+        val stroke = StrokePath(
+            Path().apply {
+                moveTo(400f, 300f)
+                lineTo(415f, 300f)
+            },
+            Color.Red,
+            30f,
+            1f,
+        )
+        val layer = renderDrawingLayer(listOf(stroke), 800, 600, 400, 400)
+        assertEquals(android.graphics.Color.RED, layer[200, 200])
+        assertEquals(0, android.graphics.Color.alpha(layer[100, 100]))
+    }
+
+    @Test
+    fun exportPreservesBlurAndErasesOnlyTheDrawing() {
+        val brush = StrokePath(
+            Path().apply {
+                moveTo(25f, 50f)
+                lineTo(75f, 50f)
+            },
+            Color.Red,
+            40f,
+            1f,
+            blurRadius = 10f,
+        )
+        val eraser = StrokePath(
+            Path().apply {
+                moveTo(50f, 30f)
+                lineTo(50f, 70f)
+            },
+            Color.Transparent,
+            10f,
+            1f,
+            isEraser = true,
+        )
+        val layer = renderDrawingLayer(listOf(brush, eraser), 100, 100, 100, 100)
+        assertEquals(0, android.graphics.Color.alpha(layer[50, 50]))
+        assertTrue(android.graphics.Color.alpha(layer[35, 25]) in 1..254)
+        assertEquals(0, android.graphics.Color.alpha(layer[0, 0]))
+    }
+
+    @Test
+    fun fullImageExportRetainsDrawingsOutsideTheInpaintMask() {
+        val result = createBitmap(400, 400).apply { eraseColor(android.graphics.Color.BLUE) }
+        val drawing = createBitmap(200, 200)
+        Canvas(drawing).drawRect(10f, 10f, 30f, 30f, Paint().apply { color = android.graphics.Color.RED })
+        val patch = createBitmap(200, 200).apply { eraseColor(android.graphics.Color.GREEN) }
+        val mask = createBitmap(200, 200)
+        Canvas(mask).drawRect(90f, 90f, 110f, 110f, Paint().apply { color = android.graphics.Color.WHITE })
+        drawImageOverlay(result, drawing, Rect(100, 100, 300, 300))
+        drawInpaintPatch(result, patch, mask, 100, 100)
+        assertEquals(android.graphics.Color.RED, result[120, 120])
+        assertEquals(android.graphics.Color.GREEN, result[200, 200])
+        assertEquals(android.graphics.Color.BLUE, result[50, 50])
+    }
+
+    @Test
+    fun laterDrawingSessionsPreserveEarlierEditsWithoutMutatingTheirSnapshot() {
+        val first = createBitmap(100, 100).apply { set(10, 10, android.graphics.Color.RED) }
+        val second = createBitmap(100, 100).apply { set(20, 20, android.graphics.Color.BLUE) }
+        val combined = mergeDrawingLayers(first, second)
+        assertEquals(android.graphics.Color.RED, combined[10, 10])
+        assertEquals(android.graphics.Color.BLUE, combined[20, 20])
+        assertEquals(0, first[20, 20])
+    }
+
+    @Test
+    fun nonSquareDrawingAndMaskUseTheSameUploadCoordinates() {
+        val drawing = createBitmap(768, 1024).apply { set(192, 64, android.graphics.Color.RED) }
+        val mask = createBitmap(768, 1024).apply { set(192, 64, android.graphics.Color.WHITE) }
+        val upload = padBitmapToCanvas(drawing, 1024, 1024)
+        val maskUpload = padBitmapToCanvas(mask, 1024, 1024)
+        assertEquals(1024, upload.width)
+        assertEquals(android.graphics.Color.RED, upload[320, 64])
+        assertEquals(android.graphics.Color.WHITE, maskUpload[320, 64])
+    }
+
+    @Test
+    fun doneReturnsTheEditedImageAndTransparentDrawing() {
+        val saved = AtomicReference<Pair<Bitmap, Bitmap>?>(null)
+        val original = createBitmap(300, 200).apply { eraseColor(android.graphics.Color.WHITE) }
+        compose.setContent {
+            MaterialTheme {
+                DrawScreen(original, { image, layer -> saved.set(image to layer) }, {})
+            }
+        }
+        compose.onNodeWithTag("drawing_canvas").performTouchInput {
+            swipe(center, center + Offset(50f, 0f))
+        }
+        compose.onNodeWithText("Done").performClick()
+        compose.waitUntil(5_000) { saved.get() != null }
+        val (image, layer) = saved.get()!!
+        assertEquals(300, image.width)
+        assertEquals(200, image.height)
+        assertEquals(android.graphics.Color.WHITE, image[0, 0])
+        assertEquals(0, android.graphics.Color.alpha(layer[0, 0]))
+        assertTrue(android.graphics.Color.alpha(layer[150, 100]) > 0)
+        assertTrue(image[150, 100] != android.graphics.Color.WHITE)
+    }
+
+    @Test
+    fun systemBackDismissesTheDrawingScreen() {
+        val dismissed = AtomicBoolean(false)
+        compose.setContent {
+            MaterialTheme {
+                DrawScreen(createBitmap(100, 100), { _, _ -> }, { dismissed.set(true) })
+            }
+        }
+        compose.waitForIdle()
+        Espresso.pressBack()
+        compose.runOnIdle { assertTrue(dismissed.get()) }
+    }
+
+    @Test
+    fun zoomTransformsTheTouchpadIndicatorWithTheDrawing() {
+        compose.setContent {
+            MaterialTheme { DrawScreen(createBitmap(100, 100), { _, _ -> }, {}) }
+        }
+        val canvas = compose.onNodeWithTag("drawing_canvas")
+        canvas.performTouchInput { swipe(center, center + Offset(50f, 0f)) }
+        val center = canvas.fetchSemanticsNode().boundsInRoot.center
+        val before = compose.onNodeWithTag("brush_indicator").fetchSemanticsNode().boundsInRoot
+        compose.onNodeWithContentDescription("Zoom").performClick()
+        canvas.performTouchInput {
+            down(0, this.center - Offset(100f, 0f))
+            down(1, this.center + Offset(100f, 0f))
+            updatePointerTo(0, this.center - Offset(150f, 0f))
+            updatePointerTo(1, this.center + Offset(250f, 0f))
+            move()
+            up(0)
+            up(1)
+        }
+        val after = compose.onNodeWithTag("brush_indicator").fetchSemanticsNode().boundsInRoot
+        val scale = after.width / before.width
+        assertTrue("Zoom was applied", scale > 1.5f)
+        assertEquals(center.x + (before.center.x - center.x) * scale + 50f, after.center.x, 2f)
+    }
+}

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/DrawScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/DrawScreen.kt
@@ -11,12 +11,13 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import android.graphics.Shader
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Canvas as ComposeCanvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
@@ -69,20 +70,19 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -90,11 +90,16 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.core.content.edit
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.get
-import androidx.compose.foundation.Canvas as ComposeCanvas
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 enum class CloneMode { OFF, SELECTING, DRAWING }
 
@@ -108,14 +113,58 @@ data class StrokePath(
     val cloneShader: BitmapShader? = null,
 )
 
+private fun StrokePath.matchesBrush(color: Color, width: Float, alpha: Float, blur: Float, shader: BitmapShader?): Boolean = !isEraser && this.color == color && strokeWidth == width && this.alpha == alpha &&
+    blurRadius == blur && cloneShader == shader
+
+private fun drawStrokePaths(canvas: Canvas, paths: List<StrokePath>) {
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeJoin = Paint.Join.ROUND
+        strokeCap = Paint.Cap.ROUND
+    }
+    paths.forEach { stroke ->
+        paint.strokeWidth = stroke.strokeWidth
+        paint.maskFilter = if (stroke.blurRadius > 0f) {
+            BlurMaskFilter(stroke.blurRadius, BlurMaskFilter.Blur.NORMAL)
+        } else {
+            null
+        }
+        paint.color = stroke.color.toArgb()
+        paint.alpha = (stroke.alpha * 255).toInt()
+        paint.shader = if (stroke.isEraser) null else stroke.cloneShader
+        paint.xfermode = if (stroke.isEraser) PorterDuffXfermode(PorterDuff.Mode.DST_OUT) else null
+        canvas.drawPath(stroke.path.asAndroidPath(), paint)
+    }
+}
+
+internal fun renderDrawingLayer(
+    paths: List<StrokePath>,
+    viewportWidth: Int,
+    viewportHeight: Int,
+    bitmapWidth: Int,
+    bitmapHeight: Int,
+): Bitmap {
+    val scale = minOf(viewportWidth.toFloat() / bitmapWidth, viewportHeight.toFloat() / bitmapHeight)
+    val offsetX = (viewportWidth - bitmapWidth * scale) / 2f
+    val offsetY = (viewportHeight - bitmapHeight * scale) / 2f
+    val layer = createBitmap(bitmapWidth, bitmapHeight)
+    val canvas = Canvas(layer)
+    canvas.scale(1f / scale, 1f / scale)
+    canvas.translate(-offsetX, -offsetY)
+    drawStrokePaths(canvas, paths)
+    return layer
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DrawScreen(
     originalBitmap: Bitmap,
-    onDrawingSaved: (Bitmap) -> Unit,
+    onDrawingSaved: suspend (Bitmap, Bitmap) -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var isSaving by remember { mutableStateOf(false) }
     val prefs = remember { context.getSharedPreferences("brush_prefs", Context.MODE_PRIVATE) }
     var brushColor by remember { mutableStateOf(Color(prefs.getInt("brush_color", Color.Red.toArgb()))) }
     var brushSize by remember { mutableFloatStateOf(prefs.getFloat("brush_size", 60f)) }
@@ -142,7 +191,7 @@ fun DrawScreen(
     var zoomOffset by remember { mutableStateOf(Offset.Zero) }
     var showColorPickerDialog by remember { mutableStateOf(false) }
     var isAdjustingBrush by remember { mutableStateOf(false) }
-    val showPreview = isTouchpadMode || (cloneMode == CloneMode.SELECTING)
+    val showPreview = isTouchpadMode || isAdjustingBrush || (cloneMode == CloneMode.SELECTING)
     var previewOffset by remember { mutableStateOf(Offset.Zero) }
     var isOffsetInitialized by remember { mutableStateOf(false) }
 
@@ -152,13 +201,25 @@ fun DrawScreen(
     var forceNewLayerNextDraw by remember { mutableStateOf(false) }
 
     var showClearDialog by remember { mutableStateOf(false) }
+    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
+    val previewBitmap = remember(viewportSize) {
+        if (viewportSize.width > 0 && viewportSize.height > 0) {
+            createBitmap(viewportSize.width, viewportSize.height)
+        } else {
+            null
+        }
+    }
+
+    BackHandler {
+        if (!isSaving) onNavigateBack()
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Drawing") },
                 navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
+                    IconButton(onClick = onNavigateBack, enabled = !isSaving) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",
@@ -169,64 +230,42 @@ fun DrawScreen(
                     Button(
                         onClick = {
                             if (paths.isEmpty()) {
-                                onNavigateBack(); return@Button
+                                onNavigateBack()
+                                return@Button
                             }
-                            val drawingBitmap = createBitmap(originalBitmap.width, originalBitmap.height)
-                            val drawingCanvas = Canvas(drawingBitmap)
-                            val paint = Paint().apply {
-                                isAntiAlias = true
-                                style = Paint.Style.STROKE
-                                strokeJoin = Paint.Join.ROUND
-                                strokeCap = Paint.Cap.ROUND
+                            val coords = imageCoordinates ?: return@Button
+                            val viewport = coords.size
+                            if (viewport.width <= 0 || viewport.height <= 0) return@Button
+                            // Keep the saved strokes stable while rendering off the UI thread.
+                            val savedPaths = paths.map { stroke ->
+                                stroke.copy(path = Path().apply { addPath(stroke.path) })
                             }
-                            val coords = imageCoordinates
-                            if (coords != null && coords.size.width > 0 && coords.size.height > 0) {
-                                val containerWidth = coords.size.width.toFloat()
-                                val containerHeight = coords.size.height.toFloat()
-                                val bitmapWidth = originalBitmap.width.toFloat()
-                                val bitmapHeight = originalBitmap.height.toFloat()
-                                val scale = minOf(containerWidth / bitmapWidth, containerHeight / bitmapHeight)
-                                val offsetX = (containerWidth - (bitmapWidth * scale)) / 2f
-                                val offsetY = (containerHeight - (bitmapHeight * scale)) / 2f
-
-                                drawingCanvas.save()
-                                drawingCanvas.scale(1f / scale, 1f / scale)
-                                drawingCanvas.translate(-offsetX, -offsetY)
-                                paths.forEach { strokePath ->
-                                    paint.strokeWidth = strokePath.strokeWidth
-                                    paint.maskFilter = if (strokePath.blurRadius > 0f) {
-                                        BlurMaskFilter(strokePath.blurRadius, BlurMaskFilter.Blur.NORMAL)
-                                    } else null
-
-                                    if (strokePath.isEraser) {
-                                        paint.shader = null
-                                        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
-                                        paint.setARGB((strokePath.alpha * 255).toInt(), 0, 0, 0)
-                                    } else {
-                                        paint.xfermode = null
-                                        if (strokePath.cloneShader != null) {
-                                            paint.shader = strokePath.cloneShader
-                                            paint.alpha = (strokePath.alpha * 255).toInt()
-                                        } else {
-                                            paint.shader = null
-                                            val c = strokePath.color
-                                            paint.setARGB(
-                                                (strokePath.alpha * 255).toInt(),
-                                                (c.red * 255).toInt(),
-                                                (c.green * 255).toInt(),
-                                                (c.blue * 255).toInt(),
-                                            )
-                                        }
+                            isSaving = true
+                            scope.launch {
+                                try {
+                                    val (result, drawing) = withContext(Dispatchers.Default) {
+                                        val layer = renderDrawingLayer(
+                                            savedPaths,
+                                            viewport.width,
+                                            viewport.height,
+                                            originalBitmap.width,
+                                            originalBitmap.height,
+                                        )
+                                        val result = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
+                                        Canvas(result).drawBitmap(layer, 0f, 0f, null)
+                                        result to layer
                                     }
-                                    drawingCanvas.drawPath(strokePath.path.asAndroidPath(), paint)
+                                    onDrawingSaved(result, drawing)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Toast.makeText(context, "Failed to save drawing: ${e.message}", Toast.LENGTH_LONG).show()
+                                } finally {
+                                    isSaving = false
                                 }
-                                drawingCanvas.restore()
-                                val resultBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
-                                Canvas(resultBitmap).drawBitmap(drawingBitmap, 0f, 0f, null)
-                                drawingBitmap.recycle()
-                                onDrawingSaved(resultBitmap)
                             }
                         },
+                        enabled = !isSaving,
                     ) { Text("Done") }
                 },
             )
@@ -244,47 +283,62 @@ fun DrawScreen(
                         currentSize = currentSize,
                         onSizeChange = { value ->
                             if (isEraserMode) {
-                                eraserSize = value; prefs.edit { putFloat("eraser_size", value) }
+                                eraserSize = value
+                                prefs.edit { putFloat("eraser_size", value) }
                             } else {
-                                brushSize = value; prefs.edit { putFloat("brush_size", value) }
+                                brushSize = value
+                                prefs.edit { putFloat("brush_size", value) }
                             }
                             isAdjustingBrush = true
                         },
                         currentAlpha = currentAlpha,
                         onAlphaChange = { value ->
                             if (isEraserMode) {
-                                eraserAlpha = value; prefs.edit { putFloat("eraser_alpha", value) }
+                                eraserAlpha = value
+                                prefs.edit { putFloat("eraser_alpha", value) }
                             } else {
-                                brushAlpha = value; prefs.edit { putFloat("brush_alpha", value) }
+                                brushAlpha = value
+                                prefs.edit { putFloat("brush_alpha", value) }
                             }
                             isAdjustingBrush = true
                         },
                         currentBlur = currentBlur,
                         onBlurChange = { value ->
                             if (isEraserMode) {
-                                eraserBlur = value; prefs.edit { putFloat("eraser_blur", value) }
+                                eraserBlur = value
+                                prefs.edit { putFloat("eraser_blur", value) }
                             } else {
-                                brushBlur = value; prefs.edit { putFloat("brush_blur", value) }
+                                brushBlur = value
+                                prefs.edit { putFloat("brush_blur", value) }
                             }
                             isAdjustingBrush = true
                         },
                         isEraserMode = isEraserMode,
                         onEraserModeChange = {
-                            isEraserMode = it; if (it) {
-                            isPickerMode = false; isZoomMode = false; cloneMode = CloneMode.OFF
-                        }
+                            isEraserMode = it
+                            if (it) {
+                                isPickerMode = false
+                                isZoomMode = false
+                                cloneMode = CloneMode.OFF
+                            }
                         },
                         isPickerMode = isPickerMode,
                         onPickerModeChange = {
-                            isPickerMode = it; if (it) {
-                            isEraserMode = false; isZoomMode = false; cloneMode = CloneMode.OFF
-                        }
+                            isPickerMode = it
+                            if (it) {
+                                isEraserMode = false
+                                isZoomMode = false
+                                cloneMode = CloneMode.OFF
+                            }
                         },
                         isZoomMode = isZoomMode,
                         onZoomModeChange = {
-                            isZoomMode = it; if (it) {
-                            isEraserMode = false; isPickerMode = false; cloneMode = CloneMode.OFF
-                        }
+                            isZoomMode = it
+                            if (it) {
+                                isEraserMode = false
+                                isPickerMode = false
+                                cloneMode = CloneMode.OFF
+                            }
                         },
                         isTouchpadMode = isTouchpadMode,
                         onTouchpadModeChange = { isTouchpadMode = it },
@@ -294,18 +348,21 @@ fun DrawScreen(
                         },
                         onAdjustmentStateChange = { isDragging -> isAdjustingBrush = isDragging },
                         onNewLayerClick = {
-                            forceNewLayerNextDraw = true; Toast.makeText(
-                            context,
-                            "New layer",
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                            forceNewLayerNextDraw = true
+                            Toast.makeText(
+                                context,
+                                "New layer",
+                                Toast.LENGTH_SHORT,
+                            ).show()
                         },
                         cloneMode = cloneMode,
                         onCloneModeClick = {
                             when (cloneMode) {
                                 CloneMode.OFF -> {
                                     cloneMode = CloneMode.SELECTING
-                                    isEraserMode = false; isPickerMode = false; isZoomMode = false
+                                    isEraserMode = false
+                                    isPickerMode = false
+                                    isZoomMode = false
                                 }
 
                                 CloneMode.SELECTING -> {
@@ -345,7 +402,8 @@ fun DrawScreen(
                                 }
 
                                 CloneMode.DRAWING -> {
-                                    cloneMode = CloneMode.OFF; activeCloneShader = null
+                                    cloneMode = CloneMode.OFF
+                                    activeCloneShader = null
                                 }
                             }
                         },
@@ -358,7 +416,8 @@ fun DrawScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(Color.Black),
+                .background(Color.Black)
+                .clipToBounds(),
             contentAlignment = Alignment.TopStart,
         ) {
             Box(
@@ -366,22 +425,26 @@ fun DrawScreen(
                     .fillMaxSize()
                     .onGloballyPositioned {
                         imageCoordinates = it
+                        viewportSize = it.size
                         if (!isOffsetInitialized && it.size.width > 0) {
                             previewOffset = Offset(it.size.width / 2f, it.size.height / 2f)
                             isOffsetInitialized = true
                         }
                     }
+                    .testTag("drawing_canvas")
                     .graphicsLayer(
                         scaleX = zoomScale,
                         scaleY = zoomScale,
                         translationX = zoomOffset.x,
                         translationY = zoomOffset.y,
                     )
-                    .pointerInput(isZoomMode, isPickerMode, isTouchpadMode, cloneMode) {
+                    .pointerInput(isZoomMode, isPickerMode, isTouchpadMode, cloneMode, isSaving) {
+                        if (isSaving) return@pointerInput
                         if (isZoomMode) {
                             detectTransformGestures { _, pan, zoom, _ ->
+                                val panInViewport = pan * zoomScale
                                 zoomScale = (zoomScale * zoom).coerceIn(1f, 8f)
-                                zoomOffset = if (zoomScale > 1f) zoomOffset + pan else Offset.Zero
+                                zoomOffset = if (zoomScale > 1f) zoomOffset + panInViewport else Offset.Zero
                             }
                         } else {
                             awaitEachGesture {
@@ -473,11 +536,7 @@ fun DrawScreen(
                                             if (cloneMode == CloneMode.DRAWING && !isEraserMode) activeCloneShader else null
                                         val lastStroke = paths.lastOrNull()
 
-                                        if (!isEraserMode && !forceNewLayerNextDraw && lastStroke != null &&
-                                            !lastStroke.isEraser && lastStroke.strokeWidth == snapWidth &&
-                                            lastStroke.alpha == snapAlpha && lastStroke.blurRadius == snapBlur &&
-                                            lastStroke.color == snapColor && lastStroke.cloneShader == snapShader
-                                        ) {
+                                        if (!isEraserMode && !forceNewLayerNextDraw && lastStroke?.matchesBrush(snapColor, snapWidth, snapAlpha, snapBlur, snapShader) == true) {
                                             lastStroke.path.addPath(finishedPath)
                                         } else {
                                             paths.add(
@@ -511,111 +570,93 @@ fun DrawScreen(
                     modifier = Modifier.fillMaxSize(),
                     onDraw = {
                         pathUpdateTrigger
-                        drawIntoCanvas { canvas ->
-                            canvas.saveLayer(size.toRect(), androidx.compose.ui.graphics.Paint())
-                            val nativePaint = androidx.compose.ui.graphics.Paint().asFrameworkPaint().apply {
-                                isAntiAlias = true
-                                style = Paint.Style.STROKE
-                                strokeCap = Paint.Cap.ROUND
-                                strokeJoin = Paint.Join.ROUND
+                        // BlurMaskFilter is not supported by the hardware canvas.
+                        // Render preview strokes in software, as the saved bitmap is rendered.
+                        previewBitmap?.let { layer ->
+                            layer.eraseColor(android.graphics.Color.TRANSPARENT)
+                            val canvas = Canvas(layer)
+                            drawStrokePaths(canvas, paths)
+                            currentPath?.let { path ->
+                                drawStrokePaths(
+                                    canvas,
+                                    listOf(
+                                        StrokePath(
+                                            path = path,
+                                            color = brushColor,
+                                            strokeWidth = currentSize,
+                                            alpha = currentAlpha,
+                                            isEraser = isEraserMode,
+                                            blurRadius = currentBlur,
+                                            cloneShader = if (cloneMode == CloneMode.DRAWING) activeCloneShader else null,
+                                        ),
+                                    ),
+                                )
                             }
-                            paths.forEach { strokePath ->
-                                nativePaint.strokeWidth = strokePath.strokeWidth
-                                nativePaint.alpha = (strokePath.alpha * 255).toInt()
-                                nativePaint.maskFilter = if (strokePath.blurRadius > 0f) BlurMaskFilter(
-                                    strokePath.blurRadius,
-                                    BlurMaskFilter.Blur.NORMAL,
-                                ) else null
-
-                                if (strokePath.isEraser) {
-                                    nativePaint.shader = null
-                                    nativePaint.color = Color.Black.toArgb()
-                                    nativePaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
-                                    nativePaint.setARGB((strokePath.alpha * 255).toInt(), 0, 0, 0)
-                                } else {
-                                    nativePaint.xfermode = null
-                                    if (strokePath.cloneShader != null) {
-                                        nativePaint.shader = strokePath.cloneShader
-                                        nativePaint.alpha = (strokePath.alpha * 255).toInt()
-                                    } else {
-                                        nativePaint.shader = null
-                                        nativePaint.color = strokePath.color.toArgb()
-                                        nativePaint.alpha = (strokePath.alpha * 255).toInt()
-                                    }
-                                }
-                                canvas.nativeCanvas.drawPath(strokePath.path.asAndroidPath(), nativePaint)
-                            }
-                            currentPath?.let {
-                                nativePaint.strokeWidth = currentSize
-                                nativePaint.alpha = (currentAlpha * 255).toInt()
-                                nativePaint.maskFilter = if (currentBlur > 0f) BlurMaskFilter(
-                                    currentBlur,
-                                    BlurMaskFilter.Blur.NORMAL,
-                                ) else null
-
-                                if (isEraserMode) {
-                                    nativePaint.shader = null
-                                    nativePaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
-                                    nativePaint.setARGB((currentAlpha * 255).toInt(), 0, 0, 0)
-                                } else {
-                                    nativePaint.xfermode = null
-                                    if (cloneMode == CloneMode.DRAWING) {
-                                        nativePaint.shader = activeCloneShader
-                                        nativePaint.alpha = (currentAlpha * 255).toInt()
-                                    } else {
-                                        nativePaint.shader = null
-                                        nativePaint.color = brushColor.toArgb()
-                                        nativePaint.alpha = (currentAlpha * 255).toInt()
-                                    }
-                                }
-                                canvas.nativeCanvas.drawPath(it.asAndroidPath(), nativePaint)
-                            }
-                            canvas.restore()
+                            drawImage(layer.asImageBitmap())
                         }
                     },
                 )
-            }
-            if (showPreview) {
-                val density = LocalDensity.current
-                val brushSizeInDp = with(density) { currentSize.toDp() }
-                val isSelecting = cloneMode == CloneMode.SELECTING
-                val baseColor = if (isEraserMode) Color.White else if (isSelecting) Color.Cyan else brushColor
-                val finalAlpha = if (isEraserMode) 0.4f else if (isSelecting) 0.6f else currentAlpha
+                if (showPreview) {
+                    val density = LocalDensity.current
+                    val brushSizeInDp = with(density) { currentSize.toDp() }
+                    val isSelecting = cloneMode == CloneMode.SELECTING
+                    val baseColor = if (isEraserMode) {
+                        Color.White
+                    } else if (isSelecting) {
+                        Color.Cyan
+                    } else {
+                        brushColor
+                    }
+                    val finalAlpha = if (isEraserMode) {
+                        0.4f
+                    } else if (isSelecting) {
+                        0.6f
+                    } else {
+                        currentAlpha
+                    }
 
-                Box(
-                    modifier = Modifier
-                        .size(brushSizeInDp)
-                        .offset(
-                            x = with(density) { (previewOffset.x - currentSize / 2f).toDp() },
-                            y = with(density) { (previewOffset.y - currentSize / 2f).toDp() },
-                        )
-                        .border(
-                            width = if (isSelecting) 2.5.dp else 1.5.dp,
-                            color = if (isEraserMode) Color.Red else if (isSelecting) Color.Cyan else Color.White,
-                            shape = if (isSelecting) RectangleShape else CircleShape,
-                        ),
-                ) {
-                    if (cloneMode != CloneMode.SELECTING) {
-                        ComposeCanvas(modifier = Modifier.fillMaxSize()) {
-                            val radius = size.minDimension / 2f
-                            if (currentBlur > 0f) {
-                                val ratio = (currentBlur / currentSize).coerceIn(0f, 0.5f)
-                                val startRadiusRatio = (1f - ratio * 2f).coerceIn(0f, 1f)
-                                drawCircle(
-                                    brush = Brush.radialGradient(
-                                        colorStops = arrayOf(
-                                            0.0f to baseColor.copy(alpha = finalAlpha),
-                                            startRadiusRatio to baseColor.copy(alpha = finalAlpha),
-                                            1.0f to Color.Transparent,
+                    Box(
+                        modifier = Modifier
+                            .size(brushSizeInDp)
+                            .offset(
+                                x = with(density) { (previewOffset.x - currentSize / 2f).toDp() },
+                                y = with(density) { (previewOffset.y - currentSize / 2f).toDp() },
+                            )
+                            .testTag("brush_indicator")
+                            .border(
+                                width = if (isSelecting) 2.5.dp else 1.5.dp,
+                                color = if (isEraserMode) {
+                                    Color.Red
+                                } else if (isSelecting) {
+                                    Color.Cyan
+                                } else {
+                                    Color.White
+                                },
+                                shape = if (isSelecting) RectangleShape else CircleShape,
+                            ),
+                    ) {
+                        if (cloneMode != CloneMode.SELECTING) {
+                            ComposeCanvas(modifier = Modifier.fillMaxSize()) {
+                                val radius = size.minDimension / 2f
+                                if (currentBlur > 0f) {
+                                    val ratio = (currentBlur / currentSize).coerceIn(0f, 0.5f)
+                                    val startRadiusRatio = (1f - ratio * 2f).coerceIn(0f, 1f)
+                                    drawCircle(
+                                        brush = Brush.radialGradient(
+                                            colorStops = arrayOf(
+                                                0.0f to baseColor.copy(alpha = finalAlpha),
+                                                startRadiusRatio to baseColor.copy(alpha = finalAlpha),
+                                                1.0f to Color.Transparent,
+                                            ),
+                                            center = center,
+                                            radius = radius,
                                         ),
-                                        center = center,
                                         radius = radius,
-                                    ),
-                                    radius = radius,
-                                    center = center,
-                                )
-                            } else {
-                                drawCircle(color = baseColor.copy(alpha = finalAlpha), radius = radius, center = center)
+                                        center = center,
+                                    )
+                                } else {
+                                    drawCircle(color = baseColor.copy(alpha = finalAlpha), radius = radius, center = center)
+                                }
                             }
                         }
                     }
@@ -625,12 +666,13 @@ fun DrawScreen(
                 SimpleColorPickerDialog(
                     initialColor = brushColor,
                     onColorSelected = { pickedColor ->
-                        brushColor = pickedColor; prefs.edit {
-                        putInt(
-                            "brush_color",
-                            pickedColor.toArgb(),
-                        )
-                    }
+                        brushColor = pickedColor
+                        prefs.edit {
+                            putInt(
+                                "brush_color",
+                                pickedColor.toArgb(),
+                            )
+                        }
                     },
                     onDismiss = { showColorPickerDialog = false },
                 )
@@ -646,7 +688,6 @@ fun DrawScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-
                         paths.clear()
                         zoomScale = 1f
                         zoomOffset = Offset.Zero
@@ -744,7 +785,7 @@ fun BrushToolsComponent(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            //horizontalArrangement = Arrangement.SpaceBetween,
+            // horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // Current color / Select color
@@ -792,18 +833,15 @@ fun BrushToolsComponent(
             FilledIconToggleButton(checked = false, onCheckedChange = { onUndo() }) {
                 Icon(imageVector = Icons.AutoMirrored.Default.Undo, contentDescription = "Undo")
             }
-
         }
-
 
         Spacer(modifier = Modifier.height(8.dp))
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            //horizontalArrangement = Arrangement.Spa,
+            // horizontalArrangement = Arrangement.Spa,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-
             // Zoom
             FilledIconToggleButton(checked = isZoomMode, onCheckedChange = onZoomModeChange) {
                 Icon(imageVector = Icons.Default.Search, contentDescription = "Zoom")
@@ -821,7 +859,6 @@ fun BrushToolsComponent(
             FilledIconToggleButton(checked = false, onCheckedChange = { onClearAll() }) {
                 Icon(imageVector = Icons.Default.Delete, contentDescription = "Clear all")
             }
-
         }
     }
 }
@@ -834,28 +871,38 @@ fun SimpleColorPickerDialog(initialColor: Color, onColorSelected: (Color) -> Uni
     LaunchedEffect(initialColor) {
         val hsv = FloatArray(3)
         android.graphics.Color.colorToHSV(initialColor.toArgb(), hsv)
-        hue = hsv[0]; saturation = hsv[1]; value = hsv[2]
+        hue = hsv[0]
+        saturation = hsv[1]
+        value = hsv[2]
     }
     val currentSelectedColor = remember(hue, saturation, value) { Color.hsv(hue, saturation, value) }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Выберите цвет") },
+        title = { Text("Select color") },
         text = {
             Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
                 Box(
                     modifier = Modifier
                         .size(200.dp)
                         .background(
-                            brush = Brush.verticalGradient(colors = listOf(Color.White, Color.Black)),
+                            brush = Brush.horizontalGradient(colors = listOf(Color.White, Color.hsv(hue, 1f, 1f))),
                             shape = MaterialTheme.shapes.medium,
                         )
                         .pointerInput(hue) {
-                            detectDragGestures { change, _ ->
-                                change.consume()
-                                val x = change.position.x.coerceIn(0f, size.width.toFloat())
-                                val y = change.position.y.coerceIn(0f, size.height.toFloat())
-                                saturation = x / size.width.toFloat()
-                                value = 1f - (y / size.height.toFloat())
+                            awaitEachGesture {
+                                val down = awaitFirstDown()
+                                fun select(position: Offset) {
+                                    saturation = (position.x / size.width).coerceIn(0f, 1f)
+                                    value = 1f - (position.y / size.height).coerceIn(0f, 1f)
+                                }
+                                select(down.position)
+                                down.consume()
+                                do {
+                                    val event = awaitPointerEvent()
+                                    val change = event.changes.first()
+                                    select(change.position)
+                                    change.consume()
+                                } while (event.changes.any { it.pressed })
                             }
                         },
                 ) {
@@ -863,12 +910,7 @@ fun SimpleColorPickerDialog(initialColor: Color, onColorSelected: (Color) -> Uni
                         modifier = Modifier
                             .fillMaxSize()
                             .background(
-                                brush = Brush.horizontalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        Color.hsv(hue, 1f, 1f),
-                                    ),
-                                ),
+                                brush = Brush.verticalGradient(colors = listOf(Color.Transparent, Color.Black)),
                                 shape = MaterialTheme.shapes.medium,
                             ),
                     )
@@ -920,7 +962,7 @@ fun SimpleColorPickerDialog(initialColor: Color, onColorSelected: (Color) -> Uni
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Text("Результат:")
+                    Text("Result:")
                     Box(
                         modifier = Modifier
                             .size(60.dp, 30.dp)
@@ -930,7 +972,12 @@ fun SimpleColorPickerDialog(initialColor: Color, onColorSelected: (Color) -> Uni
                 }
             }
         },
-        confirmButton = { Button(onClick = { onColorSelected(currentSelectedColor); onDismiss() }) { Text("Select") } },
+        confirmButton = {
+            Button(onClick = {
+                onColorSelected(currentSelectedColor)
+                onDismiss()
+            }) { Text("Select") }
+        },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
 }

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/DrawScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/DrawScreen.kt
@@ -1,0 +1,936 @@
+package io.github.xororz.localdream.ui.screens
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.BlurMaskFilter
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.Shader
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Approval
+import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.Colorize
+import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material.icons.filled.TouchApp
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.asAndroidPath
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.get
+import androidx.compose.foundation.Canvas as ComposeCanvas
+
+enum class CloneMode { OFF, SELECTING, DRAWING }
+
+data class StrokePath(
+    val path: Path,
+    val color: Color,
+    val strokeWidth: Float,
+    val alpha: Float,
+    val isEraser: Boolean = false,
+    val blurRadius: Float = 0f,
+    val cloneShader: BitmapShader? = null,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DrawScreen(
+    originalBitmap: Bitmap,
+    onDrawingSaved: (Bitmap) -> Unit,
+    onNavigateBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("brush_prefs", Context.MODE_PRIVATE) }
+    var brushColor by remember { mutableStateOf(Color(prefs.getInt("brush_color", Color.Red.toArgb()))) }
+    var brushSize by remember { mutableFloatStateOf(prefs.getFloat("brush_size", 60f)) }
+    var brushAlpha by remember { mutableFloatStateOf(prefs.getFloat("brush_alpha", 1f)) }
+    var brushBlur by remember { mutableFloatStateOf(prefs.getFloat("brush_blur", 10f)) }
+    var eraserSize by remember { mutableFloatStateOf(prefs.getFloat("eraser_size", 60f)) }
+    var eraserAlpha by remember { mutableFloatStateOf(prefs.getFloat("eraser_alpha", 1f)) }
+    var eraserBlur by remember { mutableFloatStateOf(prefs.getFloat("eraser_blur", 0f)) }
+
+    val paths = remember { mutableStateListOf<StrokePath>() }
+    var currentPath by remember { mutableStateOf<Path?>(null) }
+    var pathUpdateTrigger by remember { mutableStateOf(0) }
+    var imageCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+
+    var isEraserMode by remember { mutableStateOf(false) }
+    var isPickerMode by remember { mutableStateOf(false) }
+    var isZoomMode by remember { mutableStateOf(false) }
+    var isTouchpadMode by remember { mutableStateOf(true) }
+
+    var cloneMode by remember { mutableStateOf(CloneMode.OFF) }
+    var activeCloneShader by remember { mutableStateOf<BitmapShader?>(null) }
+
+    var zoomScale by remember { mutableFloatStateOf(1f) }
+    var zoomOffset by remember { mutableStateOf(Offset.Zero) }
+    var showColorPickerDialog by remember { mutableStateOf(false) }
+    var isAdjustingBrush by remember { mutableStateOf(false) }
+    val showPreview = isTouchpadMode || (cloneMode == CloneMode.SELECTING)
+    var previewOffset by remember { mutableStateOf(Offset.Zero) }
+    var isOffsetInitialized by remember { mutableStateOf(false) }
+
+    val currentSize = if (isEraserMode) eraserSize else brushSize
+    val currentAlpha = if (isEraserMode) eraserAlpha else brushAlpha
+    val currentBlur = if (isEraserMode) eraserBlur else brushBlur
+    var forceNewLayerNextDraw by remember { mutableStateOf(false) }
+
+    var showClearDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Drawing") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    Button(
+                        onClick = {
+                            if (paths.isEmpty()) {
+                                onNavigateBack(); return@Button
+                            }
+                            val drawingBitmap = createBitmap(originalBitmap.width, originalBitmap.height)
+                            val drawingCanvas = Canvas(drawingBitmap)
+                            val paint = Paint().apply {
+                                isAntiAlias = true
+                                style = Paint.Style.STROKE
+                                strokeJoin = Paint.Join.ROUND
+                                strokeCap = Paint.Cap.ROUND
+                            }
+                            val coords = imageCoordinates
+                            if (coords != null && coords.size.width > 0 && coords.size.height > 0) {
+                                val containerWidth = coords.size.width.toFloat()
+                                val containerHeight = coords.size.height.toFloat()
+                                val bitmapWidth = originalBitmap.width.toFloat()
+                                val bitmapHeight = originalBitmap.height.toFloat()
+                                val scale = minOf(containerWidth / bitmapWidth, containerHeight / bitmapHeight)
+                                val offsetX = (containerWidth - (bitmapWidth * scale)) / 2f
+                                val offsetY = (containerHeight - (bitmapHeight * scale)) / 2f
+
+                                drawingCanvas.save()
+                                drawingCanvas.scale(1f / scale, 1f / scale)
+                                drawingCanvas.translate(-offsetX, -offsetY)
+                                paths.forEach { strokePath ->
+                                    paint.strokeWidth = strokePath.strokeWidth
+                                    paint.maskFilter = if (strokePath.blurRadius > 0f) {
+                                        BlurMaskFilter(strokePath.blurRadius, BlurMaskFilter.Blur.NORMAL)
+                                    } else null
+
+                                    if (strokePath.isEraser) {
+                                        paint.shader = null
+                                        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
+                                        paint.setARGB((strokePath.alpha * 255).toInt(), 0, 0, 0)
+                                    } else {
+                                        paint.xfermode = null
+                                        if (strokePath.cloneShader != null) {
+                                            paint.shader = strokePath.cloneShader
+                                            paint.alpha = (strokePath.alpha * 255).toInt()
+                                        } else {
+                                            paint.shader = null
+                                            val c = strokePath.color
+                                            paint.setARGB(
+                                                (strokePath.alpha * 255).toInt(),
+                                                (c.red * 255).toInt(),
+                                                (c.green * 255).toInt(),
+                                                (c.blue * 255).toInt(),
+                                            )
+                                        }
+                                    }
+                                    drawingCanvas.drawPath(strokePath.path.asAndroidPath(), paint)
+                                }
+                                drawingCanvas.restore()
+                                val resultBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
+                                Canvas(resultBitmap).drawBitmap(drawingBitmap, 0f, 0f, null)
+                                drawingBitmap.recycle()
+                                onDrawingSaved(resultBitmap)
+                            }
+                        },
+                    ) { Text("Done") }
+                },
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surface)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
+            ) {
+                Column {
+                    BrushToolsComponent(
+                        currentColor = brushColor,
+                        onColorClick = { showColorPickerDialog = true },
+                        currentSize = currentSize,
+                        onSizeChange = { value ->
+                            if (isEraserMode) {
+                                eraserSize = value; prefs.edit { putFloat("eraser_size", value) }
+                            } else {
+                                brushSize = value; prefs.edit { putFloat("brush_size", value) }
+                            }
+                            isAdjustingBrush = true
+                        },
+                        currentAlpha = currentAlpha,
+                        onAlphaChange = { value ->
+                            if (isEraserMode) {
+                                eraserAlpha = value; prefs.edit { putFloat("eraser_alpha", value) }
+                            } else {
+                                brushAlpha = value; prefs.edit { putFloat("brush_alpha", value) }
+                            }
+                            isAdjustingBrush = true
+                        },
+                        currentBlur = currentBlur,
+                        onBlurChange = { value ->
+                            if (isEraserMode) {
+                                eraserBlur = value; prefs.edit { putFloat("eraser_blur", value) }
+                            } else {
+                                brushBlur = value; prefs.edit { putFloat("brush_blur", value) }
+                            }
+                            isAdjustingBrush = true
+                        },
+                        isEraserMode = isEraserMode,
+                        onEraserModeChange = {
+                            isEraserMode = it; if (it) {
+                            isPickerMode = false; isZoomMode = false; cloneMode = CloneMode.OFF
+                        }
+                        },
+                        isPickerMode = isPickerMode,
+                        onPickerModeChange = {
+                            isPickerMode = it; if (it) {
+                            isEraserMode = false; isZoomMode = false; cloneMode = CloneMode.OFF
+                        }
+                        },
+                        isZoomMode = isZoomMode,
+                        onZoomModeChange = {
+                            isZoomMode = it; if (it) {
+                            isEraserMode = false; isPickerMode = false; cloneMode = CloneMode.OFF
+                        }
+                        },
+                        isTouchpadMode = isTouchpadMode,
+                        onTouchpadModeChange = { isTouchpadMode = it },
+                        onUndo = { if (paths.isNotEmpty()) paths.removeAt(paths.lastIndex) },
+                        onClearAll = {
+                            showClearDialog = true
+                        },
+                        onAdjustmentStateChange = { isDragging -> isAdjustingBrush = isDragging },
+                        onNewLayerClick = {
+                            forceNewLayerNextDraw = true; Toast.makeText(
+                            context,
+                            "New layer",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                        },
+                        cloneMode = cloneMode,
+                        onCloneModeClick = {
+                            when (cloneMode) {
+                                CloneMode.OFF -> {
+                                    cloneMode = CloneMode.SELECTING
+                                    isEraserMode = false; isPickerMode = false; isZoomMode = false
+                                }
+
+                                CloneMode.SELECTING -> {
+                                    imageCoordinates?.let { coords ->
+                                        val scale = minOf(
+                                            coords.size.width / originalBitmap.width.toFloat(),
+                                            coords.size.height / originalBitmap.height.toFloat(),
+                                        )
+                                        val offsetX = (coords.size.width - (originalBitmap.width * scale)) / 2f
+                                        val offsetY = (coords.size.height - (originalBitmap.height * scale)) / 2f
+                                        val bX = ((previewOffset.x - offsetX) / scale).toInt()
+                                            .coerceIn(0, originalBitmap.width - 1)
+                                        val bY = ((previewOffset.y - offsetY) / scale).toInt()
+                                            .coerceIn(0, originalBitmap.height - 1)
+
+                                        val radius =
+                                            (currentSize / scale / 2f).toInt().coerceIn(8, originalBitmap.width)
+                                        val startX = (bX - radius).coerceIn(0, originalBitmap.width - 1)
+                                        val startY = (bY - radius).coerceIn(0, originalBitmap.height - 1)
+                                        val endX = (bX + radius).coerceIn(0, originalBitmap.width)
+                                        val endY = (bY + radius).coerceIn(0, originalBitmap.height)
+                                        val w = endX - startX
+                                        val h = endY - startY
+
+                                        if (w > 0 && h > 0) {
+                                            val crop = Bitmap.createBitmap(originalBitmap, startX, startY, w, h)
+                                            val shader =
+                                                BitmapShader(crop, Shader.TileMode.MIRROR, Shader.TileMode.MIRROR)
+                                            val matrix = Matrix()
+                                            matrix.postScale(scale, scale)
+                                            matrix.postTranslate(startX * scale + offsetX, startY * scale + offsetY)
+                                            shader.setLocalMatrix(matrix)
+                                            activeCloneShader = shader
+                                            cloneMode = CloneMode.DRAWING
+                                        }
+                                    }
+                                }
+
+                                CloneMode.DRAWING -> {
+                                    cloneMode = CloneMode.OFF; activeCloneShader = null
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        },
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(Color.Black),
+            contentAlignment = Alignment.TopStart,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned {
+                        imageCoordinates = it
+                        if (!isOffsetInitialized && it.size.width > 0) {
+                            previewOffset = Offset(it.size.width / 2f, it.size.height / 2f)
+                            isOffsetInitialized = true
+                        }
+                    }
+                    .graphicsLayer(
+                        scaleX = zoomScale,
+                        scaleY = zoomScale,
+                        translationX = zoomOffset.x,
+                        translationY = zoomOffset.y,
+                    )
+                    .pointerInput(isZoomMode, isPickerMode, isTouchpadMode, cloneMode) {
+                        if (isZoomMode) {
+                            detectTransformGestures { _, pan, zoom, _ ->
+                                zoomScale = (zoomScale * zoom).coerceIn(1f, 8f)
+                                zoomOffset = if (zoomScale > 1f) zoomOffset + pan else Offset.Zero
+                            }
+                        } else {
+                            awaitEachGesture {
+                                var isMultiTouch = false
+                                val down = awaitFirstDown(requireUnconsumed = false)
+                                if (!isPickerMode && cloneMode != CloneMode.SELECTING) {
+                                    val startPoint = if (isTouchpadMode) previewOffset else down.position
+                                    currentPath = Path().apply { moveTo(startPoint.x, startPoint.y) }
+                                    pathUpdateTrigger++
+                                }
+                                do {
+                                    val event = awaitPointerEvent()
+                                    if (event.changes.size > 1) {
+                                        isMultiTouch = true
+                                        currentPath = null
+                                        pathUpdateTrigger++
+                                    }
+                                    val pointerChange = event.changes.first()
+                                    val dragAmount = pointerChange.position - pointerChange.previousPosition
+                                    if (isTouchpadMode || cloneMode == CloneMode.SELECTING) {
+                                        previewOffset += dragAmount
+                                    } else {
+                                        previewOffset = pointerChange.position
+                                    }
+
+                                    if (isPickerMode) {
+                                        imageCoordinates?.let { coords ->
+                                            val scale = minOf(
+                                                coords.size.width / originalBitmap.width.toFloat(),
+                                                coords.size.height / originalBitmap.height.toFloat(),
+                                            )
+                                            val offsetX = (coords.size.width - (originalBitmap.width * scale)) / 2f
+                                            val offsetY = (coords.size.height - (originalBitmap.height * scale)) / 2f
+                                            val targetPoint =
+                                                if (isTouchpadMode) previewOffset else pointerChange.position
+                                            val bitmapX = ((targetPoint.x - offsetX) / scale).toInt()
+                                                .coerceIn(0, originalBitmap.width - 1)
+                                            val bitmapY = ((targetPoint.y - offsetY) / scale).toInt()
+                                                .coerceIn(0, originalBitmap.height - 1)
+
+                                            // Усредняем цвета в радиусе вокруг точки
+                                            val sampleRadius = 5 // Радиус выборки в пикселях
+                                            var totalRed = 0f
+                                            var totalGreen = 0f
+                                            var totalBlue = 0f
+                                            var totalAlpha = 0f
+                                            var count = 0
+
+                                            for (dx in -sampleRadius..sampleRadius) {
+                                                for (dy in -sampleRadius..sampleRadius) {
+                                                    val x = (bitmapX + dx).coerceIn(0, originalBitmap.width - 1)
+                                                    val y = (bitmapY + dy).coerceIn(0, originalBitmap.height - 1)
+                                                    val pixel = originalBitmap[x, y]
+                                                    totalRed += android.graphics.Color.red(pixel)
+                                                    totalGreen += android.graphics.Color.green(pixel)
+                                                    totalBlue += android.graphics.Color.blue(pixel)
+                                                    totalAlpha += android.graphics.Color.alpha(pixel)
+                                                    count++
+                                                }
+                                            }
+
+                                            val avgRed = (totalRed / count).toInt()
+                                            val avgGreen = (totalGreen / count).toInt()
+                                            val avgBlue = (totalBlue / count).toInt()
+                                            val avgAlpha = (totalAlpha / count).toInt()
+
+                                            val pickedColor =
+                                                Color(android.graphics.Color.argb(avgAlpha, avgRed, avgGreen, avgBlue))
+                                            brushColor = pickedColor
+                                            prefs.edit { putInt("brush_color", pickedColor.toArgb()) }
+                                        }
+                                    } else if (!isMultiTouch && cloneMode != CloneMode.SELECTING) {
+                                        val currentPoint = if (isTouchpadMode) previewOffset else pointerChange.position
+                                        currentPath?.lineTo(currentPoint.x, currentPoint.y)
+                                        pathUpdateTrigger++
+                                    }
+                                    event.changes.forEach { it.consume() }
+                                } while (event.changes.any { it.pressed })
+                                if (isPickerMode) {
+                                    isPickerMode = false
+                                    Toast.makeText(context, "Color changed", Toast.LENGTH_SHORT).show()
+                                } else if (!isMultiTouch && cloneMode != CloneMode.SELECTING) {
+                                    currentPath?.let { finishedPath ->
+                                        val snapColor = if (isEraserMode) Color.Transparent else brushColor
+                                        val snapWidth = if (isEraserMode) eraserSize else brushSize
+                                        val snapAlpha = if (isEraserMode) eraserAlpha else brushAlpha
+                                        val snapBlur = if (isEraserMode) eraserBlur else brushBlur
+                                        val snapShader =
+                                            if (cloneMode == CloneMode.DRAWING && !isEraserMode) activeCloneShader else null
+                                        val lastStroke = paths.lastOrNull()
+
+                                        if (!isEraserMode && !forceNewLayerNextDraw && lastStroke != null &&
+                                            !lastStroke.isEraser && lastStroke.strokeWidth == snapWidth &&
+                                            lastStroke.alpha == snapAlpha && lastStroke.blurRadius == snapBlur &&
+                                            lastStroke.color == snapColor && lastStroke.cloneShader == snapShader
+                                        ) {
+                                            lastStroke.path.addPath(finishedPath)
+                                        } else {
+                                            paths.add(
+                                                StrokePath(
+                                                    finishedPath,
+                                                    snapColor,
+                                                    snapWidth,
+                                                    snapAlpha,
+                                                    isEraserMode,
+                                                    snapBlur,
+                                                    snapShader,
+                                                ),
+                                            )
+                                            forceNewLayerNextDraw = false
+                                        }
+                                    }
+                                }
+                                currentPath = null
+                                pathUpdateTrigger++
+                            }
+                        }
+                    },
+            ) {
+                Image(
+                    bitmap = originalBitmap.asImageBitmap(),
+                    contentDescription = "Original Background",
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                ComposeCanvas(
+                    modifier = Modifier.fillMaxSize(),
+                    onDraw = {
+                        pathUpdateTrigger
+                        drawIntoCanvas { canvas ->
+                            canvas.saveLayer(size.toRect(), androidx.compose.ui.graphics.Paint())
+                            val nativePaint = androidx.compose.ui.graphics.Paint().asFrameworkPaint().apply {
+                                isAntiAlias = true
+                                style = Paint.Style.STROKE
+                                strokeCap = Paint.Cap.ROUND
+                                strokeJoin = Paint.Join.ROUND
+                            }
+                            paths.forEach { strokePath ->
+                                nativePaint.strokeWidth = strokePath.strokeWidth
+                                nativePaint.alpha = (strokePath.alpha * 255).toInt()
+                                nativePaint.maskFilter = if (strokePath.blurRadius > 0f) BlurMaskFilter(
+                                    strokePath.blurRadius,
+                                    BlurMaskFilter.Blur.NORMAL,
+                                ) else null
+
+                                if (strokePath.isEraser) {
+                                    nativePaint.shader = null
+                                    nativePaint.color = Color.Black.toArgb()
+                                    nativePaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
+                                    nativePaint.setARGB((strokePath.alpha * 255).toInt(), 0, 0, 0)
+                                } else {
+                                    nativePaint.xfermode = null
+                                    if (strokePath.cloneShader != null) {
+                                        nativePaint.shader = strokePath.cloneShader
+                                        nativePaint.alpha = (strokePath.alpha * 255).toInt()
+                                    } else {
+                                        nativePaint.shader = null
+                                        nativePaint.color = strokePath.color.toArgb()
+                                        nativePaint.alpha = (strokePath.alpha * 255).toInt()
+                                    }
+                                }
+                                canvas.nativeCanvas.drawPath(strokePath.path.asAndroidPath(), nativePaint)
+                            }
+                            currentPath?.let {
+                                nativePaint.strokeWidth = currentSize
+                                nativePaint.alpha = (currentAlpha * 255).toInt()
+                                nativePaint.maskFilter = if (currentBlur > 0f) BlurMaskFilter(
+                                    currentBlur,
+                                    BlurMaskFilter.Blur.NORMAL,
+                                ) else null
+
+                                if (isEraserMode) {
+                                    nativePaint.shader = null
+                                    nativePaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
+                                    nativePaint.setARGB((currentAlpha * 255).toInt(), 0, 0, 0)
+                                } else {
+                                    nativePaint.xfermode = null
+                                    if (cloneMode == CloneMode.DRAWING) {
+                                        nativePaint.shader = activeCloneShader
+                                        nativePaint.alpha = (currentAlpha * 255).toInt()
+                                    } else {
+                                        nativePaint.shader = null
+                                        nativePaint.color = brushColor.toArgb()
+                                        nativePaint.alpha = (currentAlpha * 255).toInt()
+                                    }
+                                }
+                                canvas.nativeCanvas.drawPath(it.asAndroidPath(), nativePaint)
+                            }
+                            canvas.restore()
+                        }
+                    },
+                )
+            }
+            if (showPreview) {
+                val density = LocalDensity.current
+                val brushSizeInDp = with(density) { currentSize.toDp() }
+                val isSelecting = cloneMode == CloneMode.SELECTING
+                val baseColor = if (isEraserMode) Color.White else if (isSelecting) Color.Cyan else brushColor
+                val finalAlpha = if (isEraserMode) 0.4f else if (isSelecting) 0.6f else currentAlpha
+
+                Box(
+                    modifier = Modifier
+                        .size(brushSizeInDp)
+                        .offset(
+                            x = with(density) { (previewOffset.x - currentSize / 2f).toDp() },
+                            y = with(density) { (previewOffset.y - currentSize / 2f).toDp() },
+                        )
+                        .border(
+                            width = if (isSelecting) 2.5.dp else 1.5.dp,
+                            color = if (isEraserMode) Color.Red else if (isSelecting) Color.Cyan else Color.White,
+                            shape = if (isSelecting) RectangleShape else CircleShape,
+                        ),
+                ) {
+                    if (cloneMode != CloneMode.SELECTING) {
+                        ComposeCanvas(modifier = Modifier.fillMaxSize()) {
+                            val radius = size.minDimension / 2f
+                            if (currentBlur > 0f) {
+                                val ratio = (currentBlur / currentSize).coerceIn(0f, 0.5f)
+                                val startRadiusRatio = (1f - ratio * 2f).coerceIn(0f, 1f)
+                                drawCircle(
+                                    brush = Brush.radialGradient(
+                                        colorStops = arrayOf(
+                                            0.0f to baseColor.copy(alpha = finalAlpha),
+                                            startRadiusRatio to baseColor.copy(alpha = finalAlpha),
+                                            1.0f to Color.Transparent,
+                                        ),
+                                        center = center,
+                                        radius = radius,
+                                    ),
+                                    radius = radius,
+                                    center = center,
+                                )
+                            } else {
+                                drawCircle(color = baseColor.copy(alpha = finalAlpha), radius = radius, center = center)
+                            }
+                        }
+                    }
+                }
+            }
+            if (showColorPickerDialog) {
+                SimpleColorPickerDialog(
+                    initialColor = brushColor,
+                    onColorSelected = { pickedColor ->
+                        brushColor = pickedColor; prefs.edit {
+                        putInt(
+                            "brush_color",
+                            pickedColor.toArgb(),
+                        )
+                    }
+                    },
+                    onDismiss = { showColorPickerDialog = false },
+                )
+            }
+        }
+    }
+
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDialog = false },
+            title = { Text(text = "Clear canvas") },
+            text = { Text(text = "Are you sure you want to delete all drawings?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+
+                        paths.clear()
+                        zoomScale = 1f
+                        zoomOffset = Offset.Zero
+                        imageCoordinates?.let { previewOffset = Offset(it.size.width / 2f, it.size.height / 2f) }
+
+                        // Close dialog
+                        showClearDialog = false
+                    },
+                ) {
+                    Text("Clear", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+fun BrushToolsComponent(
+    currentColor: Color,
+    onColorClick: () -> Unit,
+    currentSize: Float,
+    onSizeChange: (Float) -> Unit,
+    currentAlpha: Float,
+    onAlphaChange: (Float) -> Unit,
+    currentBlur: Float,
+    onBlurChange: (Float) -> Unit,
+    isEraserMode: Boolean,
+    onEraserModeChange: (Boolean) -> Unit,
+    isPickerMode: Boolean,
+    onPickerModeChange: (Boolean) -> Unit,
+    isZoomMode: Boolean,
+    onZoomModeChange: (Boolean) -> Unit,
+    isTouchpadMode: Boolean,
+    onTouchpadModeChange: (Boolean) -> Unit,
+    onUndo: () -> Unit,
+    onClearAll: () -> Unit,
+    onAdjustmentStateChange: (Boolean) -> Unit,
+    onNewLayerClick: () -> Unit,
+    cloneMode: CloneMode,
+    onCloneModeClick: () -> Unit,
+) {
+    val sizeInteractionSource = remember { MutableInteractionSource() }
+    val alphaInteractionSource = remember { MutableInteractionSource() }
+    val blurInteractionSource = remember { MutableInteractionSource() }
+    val isSizeDragged by sizeInteractionSource.collectIsDraggedAsState()
+    val isAlphaDragged by alphaInteractionSource.collectIsDraggedAsState()
+    val isBlurDragged by blurInteractionSource.collectIsDraggedAsState()
+
+    LaunchedEffect(isSizeDragged, isAlphaDragged, isBlurDragged) {
+        onAdjustmentStateChange(isSizeDragged || isAlphaDragged || isBlurDragged)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Slider(
+                    value = currentSize,
+                    onValueChange = onSizeChange,
+                    valueRange = 5f..200f,
+                    interactionSource = sizeInteractionSource,
+                )
+                Text(text = "Size: ${currentSize.toInt()}", style = MaterialTheme.typography.bodySmall)
+            }
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Slider(
+                    value = currentAlpha,
+                    onValueChange = onAlphaChange,
+                    valueRange = 0.1f..1f,
+                    interactionSource = alphaInteractionSource,
+                )
+                Text(text = "Transp.: ${(currentAlpha * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
+            }
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Slider(
+                    value = currentBlur,
+                    onValueChange = onBlurChange,
+                    valueRange = 0f..100f,
+                    interactionSource = blurInteractionSource,
+                )
+                Text(text = "Blur: ${currentBlur.toInt()}", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            //horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Current color / Select color
+            FilledIconButton(
+                onClick = onColorClick,
+                enabled = !isEraserMode && cloneMode == CloneMode.OFF,
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = currentColor, // Цвет, когда кнопка активна
+                    disabledContainerColor = currentColor.copy(alpha = 0.38f),
+                ),
+            ) {}
+
+            // Pipette
+            FilledIconToggleButton(checked = isPickerMode, onCheckedChange = onPickerModeChange) {
+                Icon(imageVector = Icons.Default.Colorize, contentDescription = "Pipette")
+            }
+
+            // Stamp / Clone
+            FilledIconToggleButton(checked = (cloneMode != CloneMode.OFF), onCheckedChange = { onCloneModeClick() }) {
+                Icon(
+                    imageVector = when (cloneMode) {
+                        CloneMode.OFF -> Icons.Default.Approval
+                        CloneMode.SELECTING -> Icons.Default.SelectAll
+                        CloneMode.DRAWING -> Icons.Default.Brush
+                    },
+                    contentDescription = when (cloneMode) {
+                        CloneMode.OFF -> "Stamp disabled"
+                        CloneMode.SELECTING -> "Selecting"
+                        CloneMode.DRAWING -> "Drawing"
+                    },
+                )
+            }
+
+            // Eraser
+            FilledIconToggleButton(checked = isEraserMode, onCheckedChange = onEraserModeChange) {
+                Icon(imageVector = Icons.Default.ContentCut, contentDescription = "Eraser")
+            }
+
+            // New layer
+            FilledIconToggleButton(checked = false, onCheckedChange = { onNewLayerClick() }) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "New layer")
+            }
+
+            // Undo
+            FilledIconToggleButton(checked = false, onCheckedChange = { onUndo() }) {
+                Icon(imageVector = Icons.AutoMirrored.Default.Undo, contentDescription = "Undo")
+            }
+
+        }
+
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            //horizontalArrangement = Arrangement.Spa,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+
+            // Zoom
+            FilledIconToggleButton(checked = isZoomMode, onCheckedChange = onZoomModeChange) {
+                Icon(imageVector = Icons.Default.Search, contentDescription = "Zoom")
+            }
+
+            // Touch mode
+            FilledIconToggleButton(
+                checked = !isTouchpadMode,
+                onCheckedChange = { isChecked -> onTouchpadModeChange(!isChecked) },
+            ) {
+                Icon(imageVector = Icons.Default.TouchApp, contentDescription = "Touch mode")
+            }
+
+            // Clear all
+            FilledIconToggleButton(checked = false, onCheckedChange = { onClearAll() }) {
+                Icon(imageVector = Icons.Default.Delete, contentDescription = "Clear all")
+            }
+
+        }
+    }
+}
+
+@Composable
+fun SimpleColorPickerDialog(initialColor: Color, onColorSelected: (Color) -> Unit, onDismiss: () -> Unit) {
+    var hue by remember { mutableFloatStateOf(0f) }
+    var saturation by remember { mutableFloatStateOf(1f) }
+    var value by remember { mutableFloatStateOf(1f) }
+    LaunchedEffect(initialColor) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(initialColor.toArgb(), hsv)
+        hue = hsv[0]; saturation = hsv[1]; value = hsv[2]
+    }
+    val currentSelectedColor = remember(hue, saturation, value) { Color.hsv(hue, saturation, value) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Выберите цвет") },
+        text = {
+            Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+                Box(
+                    modifier = Modifier
+                        .size(200.dp)
+                        .background(
+                            brush = Brush.verticalGradient(colors = listOf(Color.White, Color.Black)),
+                            shape = MaterialTheme.shapes.medium,
+                        )
+                        .pointerInput(hue) {
+                            detectDragGestures { change, _ ->
+                                change.consume()
+                                val x = change.position.x.coerceIn(0f, size.width.toFloat())
+                                val y = change.position.y.coerceIn(0f, size.height.toFloat())
+                                saturation = x / size.width.toFloat()
+                                value = 1f - (y / size.height.toFloat())
+                            }
+                        },
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                brush = Brush.horizontalGradient(
+                                    colors = listOf(
+                                        Color.Transparent,
+                                        Color.hsv(hue, 1f, 1f),
+                                    ),
+                                ),
+                                shape = MaterialTheme.shapes.medium,
+                            ),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .offset(x = (saturation * 200).dp - 8.dp, y = ((1f - value) * 200).dp - 8.dp)
+                            .size(16.dp)
+                            .background(Color.Transparent, shape = CircleShape)
+                            .border(
+                                width = 2.dp,
+                                color = if (value < 0.5f) Color.White else Color.Black,
+                                shape = CircleShape,
+                            ),
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                val hueColors = remember {
+                    listOf(
+                        Color.Red,
+                        Color.Yellow,
+                        Color.Green,
+                        Color.Cyan,
+                        Color.Blue,
+                        Color.Magenta,
+                        Color.Red,
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(12.dp)
+                        .background(
+                            brush = Brush.horizontalGradient(colors = hueColors),
+                            shape = MaterialTheme.shapes.small,
+                        ),
+                )
+                Slider(
+                    value = hue,
+                    onValueChange = { hue = it },
+                    valueRange = 0f..360f,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = SliderDefaults.colors(
+                        activeTrackColor = Color.Transparent,
+                        inactiveTrackColor = Color.Transparent,
+                    ),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text("Результат:")
+                    Box(
+                        modifier = Modifier
+                            .size(60.dp, 30.dp)
+                            .background(currentSelectedColor, shape = MaterialTheme.shapes.small)
+                            .border(1.dp, Color.Gray, MaterialTheme.shapes.small),
+                    )
+                }
+            }
+        },
+        confirmButton = { Button(onClick = { onColorSelected(currentSelectedColor); onDismiss() }) { Text("Select") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
@@ -1086,8 +1086,58 @@ fun ModelRunScreen(
                         val mutableOriginal =
                             originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
 
-                        val rectW = snapshotCropRect!!.width()
-                        val rectH = snapshotCropRect!!.height()
+                        var rectW = snapshotCropRect!!.width()
+                        var rectH = snapshotCropRect!!.height()
+
+                        var finalLeft = snapshotCropRect!!.left
+                        var finalTop = snapshotCropRect!!.top
+
+                        // Convert 2dp rounding error margin to physical pixels based on device density
+                        val displayMetrics = context.resources.displayMetrics
+                        val density = displayMetrics.density
+                        val tolerance = (2f * density).roundToInt().coerceAtLeast(1)
+
+                        // Vertical axis adjustment (Top / Bottom)
+                        val matchesFullHeight = Math.abs(rectH - originalBitmap.height) <= tolerance
+
+                        if (matchesFullHeight) {
+                            // If the patch spans the full height, force it to take the EXACT
+                            // maximum height of the original image to prevent vertical compression.
+                            rectH = originalBitmap.height
+                            finalTop = 0
+                        } else {
+                            // Standard edge-snapping for localized vertical patches
+                            val isBottomEdge = snapshotCropRect!!.bottom >= (originalBitmap.height - tolerance)
+                            val isTopEdge = snapshotCropRect!!.top <= tolerance
+
+                            if (isBottomEdge) {
+                                finalTop = originalBitmap.height - rectH
+                            } else if (isTopEdge) {
+                                finalTop = 0
+                            }
+                        }
+
+                        // Horizontal axis adjustment (Left / Right)
+                        val matchesFullWidth = Math.abs(rectW - originalBitmap.width) <= tolerance
+
+                        if (matchesFullWidth) {
+                            // If the patch spans the full width, force it to take the EXACT
+                            // maximum width of the original image to prevent horizontal compression.
+                            rectW = originalBitmap.width
+                            finalLeft = 0
+                        } else {
+                            // Standard edge-snapping for localized horizontal patches
+                            val isRightEdge = snapshotCropRect!!.right >= (originalBitmap.width - tolerance)
+                            val isLeftEdge = snapshotCropRect!!.left <= tolerance
+
+                            if (isRightEdge) {
+                                finalLeft = originalBitmap.width - rectW
+                            } else if (isLeftEdge) {
+                                finalLeft = 0
+                            }
+                        }
+
+                        // Scale the patch to the mathematically corrected dimensions
                         val resizedPatch = bitmap.scale(rectW, rectH)
 
                         // Feather-blend along the mask instead of pasting the
@@ -1098,8 +1148,8 @@ fun ModelRunScreen(
                             target = mutableOriginal,
                             patch = resizedPatch,
                             mask = snapshotMaskBitmap,
-                            left = snapshotCropRect!!.left,
-                            top = snapshotCropRect!!.top,
+                            left = finalLeft,
+                            top = finalTop,
                         )
 
                         saveImage(

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
@@ -484,6 +484,9 @@ fun ModelRunScreen(
     var cropRect by remember { mutableStateOf<AndroidRect?>(null) }
 
     var showDrawScreen by remember { mutableStateOf(false) }
+    // Transparent edits are also retained for full-image inpaint exports.
+    var drawingOverlayBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    var snapshotDrawingOverlayBitmap by remember { mutableStateOf<Bitmap?>(null) }
 
     // True only when selectedImageUri points to a real source image from the gallery picker.
     // False when img2img was seeded from a result/history bitmap (selectedImageUri is a
@@ -564,6 +567,7 @@ fun ModelRunScreen(
     fun clearImg2imgState() {
         selectedImageUri = null
         croppedBitmap = null
+        drawingOverlayBitmap = null
         maskBitmap = null
         isInpaintMode = false
         cropRect = null
@@ -703,11 +707,12 @@ fun ModelRunScreen(
                                 val safeRight = rect.right.coerceAtMost(decoder.width)
                                 val safeBottom = rect.bottom.coerceAtMost(decoder.height)
                                 if (safeRight > safeLeft && safeBottom > safeTop) {
-                                    val region = AndroidRect(
-                                        safeLeft,
-                                        safeTop,
-                                        safeRight,
-                                        safeBottom,
+                                    val region = snapInpaintCropRect(
+                                        rect = AndroidRect(safeLeft, safeTop, safeRight, safeBottom),
+                                        imageWidth = decoder.width,
+                                        imageHeight = decoder.height,
+                                        tolerance = (2f * context.resources.displayMetrics.density)
+                                            .roundToInt().coerceAtLeast(1),
                                     )
                                     clampedRect = region
                                     decoder.decodeRegion(region, BitmapFactory.Options())
@@ -748,6 +753,7 @@ fun ModelRunScreen(
                 withContext(Dispatchers.Main) {
                     cropRect = clampedRect
                     croppedBitmap = scaled
+                    drawingOverlayBitmap = null
                 }
 
                 val tmpFile = File(context.filesDir, "tmp.txt")
@@ -762,6 +768,7 @@ fun ModelRunScreen(
                     ).show()
                     selectedImageUri = null
                     croppedBitmap = null
+                    drawingOverlayBitmap = null
                     cropRect = null
                     hasOriginalImageForStitch = false
                 }
@@ -859,6 +866,7 @@ fun ModelRunScreen(
                 }
 
                 croppedBitmap = displayBitmap
+                drawingOverlayBitmap = null
                 cropRect = AndroidRect(0, 0, displayBitmap.width, displayBitmap.height)
                 selectedImageUri = Uri.fromFile(File(context.filesDir, "tmp.txt"))
                 hasOriginalImageForStitch = false
@@ -875,6 +883,7 @@ fun ModelRunScreen(
                 base64EncodeDone = false
                 selectedImageUri = null
                 croppedBitmap = null
+                drawingOverlayBitmap = null
                 cropRect = null
                 hasOriginalImageForStitch = false
                 false
@@ -1089,58 +1098,12 @@ fun ModelRunScreen(
                         val mutableOriginal =
                             originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
 
-                        var rectW = snapshotCropRect!!.width()
-                        var rectH = snapshotCropRect!!.height()
-
-                        var finalLeft = snapshotCropRect!!.left
-                        var finalTop = snapshotCropRect!!.top
-
-                        // Convert 2dp rounding error margin to physical pixels based on device density
-                        val displayMetrics = context.resources.displayMetrics
-                        val density = displayMetrics.density
-                        val tolerance = (2f * density).roundToInt().coerceAtLeast(1)
-
-                        // Vertical axis adjustment (Top / Bottom)
-                        val matchesFullHeight = Math.abs(rectH - originalBitmap.height) <= tolerance
-
-                        if (matchesFullHeight) {
-                            // If the patch spans the full height, force it to take the EXACT
-                            // maximum height of the original image to prevent vertical compression.
-                            rectH = originalBitmap.height
-                            finalTop = 0
-                        } else {
-                            // Standard edge-snapping for localized vertical patches
-                            val isBottomEdge = snapshotCropRect!!.bottom >= (originalBitmap.height - tolerance)
-                            val isTopEdge = snapshotCropRect!!.top <= tolerance
-
-                            if (isBottomEdge) {
-                                finalTop = originalBitmap.height - rectH
-                            } else if (isTopEdge) {
-                                finalTop = 0
-                            }
+                        snapshotDrawingOverlayBitmap?.let { drawing ->
+                            drawImageOverlay(mutableOriginal, drawing, snapshotCropRect!!)
                         }
 
-                        // Horizontal axis adjustment (Left / Right)
-                        val matchesFullWidth = Math.abs(rectW - originalBitmap.width) <= tolerance
-
-                        if (matchesFullWidth) {
-                            // If the patch spans the full width, force it to take the EXACT
-                            // maximum width of the original image to prevent horizontal compression.
-                            rectW = originalBitmap.width
-                            finalLeft = 0
-                        } else {
-                            // Standard edge-snapping for localized horizontal patches
-                            val isRightEdge = snapshotCropRect!!.right >= (originalBitmap.width - tolerance)
-                            val isLeftEdge = snapshotCropRect!!.left <= tolerance
-
-                            if (isRightEdge) {
-                                finalLeft = originalBitmap.width - rectW
-                            } else if (isLeftEdge) {
-                                finalLeft = 0
-                            }
-                        }
-
-                        // Scale the patch to the mathematically corrected dimensions
+                        val rectW = snapshotCropRect!!.width()
+                        val rectH = snapshotCropRect!!.height()
                         val resizedPatch = bitmap.scale(rectW, rectH)
 
                         // Feather-blend along the mask instead of pasting the
@@ -1151,8 +1114,8 @@ fun ModelRunScreen(
                             target = mutableOriginal,
                             patch = resizedPatch,
                             mask = snapshotMaskBitmap,
-                            left = finalLeft,
-                            top = finalTop,
+                            left = snapshotCropRect!!.left,
+                            top = snapshotCropRect!!.top,
                         )
 
                         saveImage(
@@ -1496,6 +1459,7 @@ fun ModelRunScreen(
                         snapshotSelectedImageUri = selectedImageUri
                         snapshotCropRect = cropRect
                         snapshotMaskBitmap = if (isInpaintMode) maskBitmap else null
+                        snapshotDrawingOverlayBitmap = drawingOverlayBitmap
                         snapshotHasOriginalImage = hasOriginalImageForStitch
                     }
                     // stitchableHistoryIds / currentDisplayedHistoryId are set once
@@ -2308,6 +2272,7 @@ fun ModelRunScreen(
                                     onClick = {
                                         selectedImageUri = null
                                         croppedBitmap = null
+                                        drawingOverlayBitmap = null
                                         maskBitmap = null
                                         isInpaintMode = false
                                         cropRect = null
@@ -2334,6 +2299,7 @@ fun ModelRunScreen(
                                     onClick = {
                                         showDrawScreen = true
                                     },
+                                    enabled = !isRunning && croppedBitmap != null,
                                     modifier = Modifier
                                         .size(24.dp)
                                         .background(
@@ -2754,21 +2720,28 @@ fun ModelRunScreen(
                 },
             )
         }
-        if (showDrawScreen) {
+        if (showDrawScreen && croppedBitmap != null) {
             DrawScreen(
                 originalBitmap = croppedBitmap!!,
-                onDrawingSaved = { sketchedBitmap ->
+                onDrawingSaved = { sketchedBitmap, drawing ->
+                    val previousDrawing = drawingOverlayBitmap
+                    val combinedDrawing = withContext(Dispatchers.Default) {
+                        mergeDrawingLayers(previousDrawing, drawing)
+                    }
+                    withContext(Dispatchers.IO) {
+                        // Match the upload canvas used by cropping and by the inpaint mask.
+                        val upload = padBitmapToCanvas(sketchedBitmap, currentWidth, currentHeight)
+                        val payload = bitmapToBase64Png(upload)
+                        File(context.filesDir, "tmp.txt").writeText(payload)
+                        if (upload !== sketchedBitmap) upload.recycle()
+                    }
                     croppedBitmap = sketchedBitmap
-
-                    val payload = bitmapToBase64Png(croppedBitmap!!)
-                    val tmpFile = File(context.filesDir, "tmp.txt")
-                    tmpFile.writeText(payload)
-
+                    drawingOverlayBitmap = combinedDrawing
                     showDrawScreen = false
                 },
                 onNavigateBack = {
                     showDrawScreen = false
-                }
+                },
             )
         }
     }

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -481,6 +482,8 @@ fun ModelRunScreen(
     var isInpaintMode by remember { mutableStateOf(false) }
     var savedPathHistory by remember { mutableStateOf<List<PathData>?>(null) }
     var cropRect by remember { mutableStateOf<AndroidRect?>(null) }
+
+    var showDrawScreen by remember { mutableStateOf(false) }
 
     // True only when selectedImageUri points to a real source image from the gallery picker.
     // False when img2img was seeded from a result/history bitmap (selectedImageUri is a
@@ -2327,6 +2330,26 @@ fun ModelRunScreen(
                                         modifier = Modifier.size(16.dp),
                                     )
                                 }
+                                IconButton(
+                                    onClick = {
+                                        showDrawScreen = true
+                                    },
+                                    modifier = Modifier
+                                        .size(24.dp)
+                                        .background(
+                                            color = MaterialTheme.colorScheme.surface.copy(
+                                                alpha = 0.7f,
+                                            ),
+                                            shape = CircleShape,
+                                        )
+                                        .align(Alignment.TopStart),
+                                ) {
+                                    Icon(
+                                        Icons.Default.Draw,
+                                        contentDescription = "Draw Image",
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
                             }
                         }
 
@@ -2729,6 +2752,23 @@ fun ModelRunScreen(
                 onCancel = {
                     showInpaintScreen = false
                 },
+            )
+        }
+        if (showDrawScreen) {
+            DrawScreen(
+                originalBitmap = croppedBitmap!!,
+                onDrawingSaved = { sketchedBitmap ->
+                    croppedBitmap = sketchedBitmap
+
+                    val payload = bitmapToBase64Png(croppedBitmap!!)
+                    val tmpFile = File(context.filesDir, "tmp.txt")
+                    tmpFile.writeText(payload)
+
+                    showDrawScreen = false
+                },
+                onNavigateBack = {
+                    showDrawScreen = false
+                }
             )
         }
     }

--- a/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunSupport.kt
+++ b/app/src/main/java/io/github/xororz/localdream/ui/screens/ModelRunSupport.kt
@@ -272,6 +272,39 @@ fun padBitmapToCanvas(src: Bitmap, canvasW: Int, canvasH: Int): Bitmap {
     return out
 }
 
+/** Snap before decoding the crop so generation and stitching use the same pixels. */
+internal fun snapInpaintCropRect(rect: Rect, imageWidth: Int, imageHeight: Int, tolerance: Int): Rect {
+    val result = Rect(rect)
+    if (imageWidth - result.width() <= tolerance) {
+        result.left = 0
+        result.right = imageWidth
+    } else if (result.right >= imageWidth - tolerance) {
+        result.offset(imageWidth - result.right, 0)
+    } else if (result.left <= tolerance) {
+        result.offset(-result.left, 0)
+    }
+    if (imageHeight - result.height() <= tolerance) {
+        result.top = 0
+        result.bottom = imageHeight
+    } else if (result.bottom >= imageHeight - tolerance) {
+        result.offset(0, imageHeight - result.bottom)
+    } else if (result.top <= tolerance) {
+        result.offset(0, -result.top)
+    }
+    return result
+}
+
+internal fun mergeDrawingLayers(previous: Bitmap?, drawing: Bitmap): Bitmap {
+    if (previous == null) return drawing
+    return previous.copy(Bitmap.Config.ARGB_8888, true).apply {
+        Canvas(this).drawBitmap(drawing, 0f, 0f, null)
+    }
+}
+
+internal fun drawImageOverlay(target: Bitmap, drawing: Bitmap, crop: Rect) {
+    Canvas(target).drawBitmap(drawing, null, crop, Paint(Paint.FILTER_BITMAP_FLAG))
+}
+
 // Feathered inpaint stitching: the generated patch went through a
 // downscale-to-model-resolution / upscale-back round trip, so even its unmasked
 // pixels differ from the source image (lost high frequencies, resampling


### PR DESCRIPTION
### Description
This PR adds a **canvas drawing feature (`DrawScreen`)** for both **Img2Img** and **Inpaint** workflows. Users can now paint, erase, or clone details directly on top of their source images inside the app before sending them to the generation pipelines.

This is especially useful for quickly masking areas for Inpaint or adding rough color sketches/guidance for Img2Img without relying on third-party image editors.

### Key Changes
- **Custom Canvas (`DrawScreen.kt`):** A new standalone Composable screen that handles high-resolution drawing layered over the original bitmap.
- **Advanced Brush Controls:** Added sliders for brush size, transparency (alpha), and blur radius (feathering). Supports switching between Brush, Eraser, and Color Picker (pipette) modes.
- **Stamp / Clone Tool:** Implemented a stamp mode that utilizes a `BitmapShader` mirror matrix to clone parts of the source image onto the drawing path.
- **Precise Coordinate Mapping:** Drawing is done on a responsive UI viewport layer, but paths are accurately mapped back to the full-size original bitmap coordinates during saving to preserve image quality.
- **UI/UX Utilities:** Supports multi-touch zooming/panning for detailed work, a gesture-based "touchpad" indicator mode, undo functionality, and a clear-canvas dialog.

### Testing
- Tested drawing, erasing, and cloning on various image sizes.
- Verified that output bitmaps are correctly formatted and successfully passed into Img2Img and Inpaint pipelines.
